### PR TITLE
Replace the SVN repository variables with their git equivalents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ ZIP = zip
 
 export TEXINPUTS=.:ivoatex:
 
+# Version information extracted from git.
+GITVERSION := $(shell git log -1 --date=short --pretty=%h 2> /dev/null)
+GITDATE := $(shell git log -1 --date=short --pretty=%ai 2> /dev/null)
+GITSTATUS := $(shell git status --porcelain -uno 2> /dev/null)
+ifneq "$(GITSTATUS)" ""
+	GITDIRTY = -dirty
+endif
+
 # standard file name according to S&D standards
 versionedName:=$(DOCTYPE)-$(DOCNAME)-$(DOCVERSION)
 ifneq "$(DOCTYPE)" "REC"
@@ -79,7 +87,9 @@ clean:
 	rm -f arxiv-upload.tar.gz
 	rm -f $(GENERATED_PNGS)
 
-ivoatexmeta.tex: Makefile
+.FORCE:
+
+ivoatexmeta.tex: Makefile .FORCE
 	rm -f $@
 	touch $@
 	echo '% GENERATED FILE -- edit this in the Makefile' >>$@
@@ -88,6 +98,12 @@ ivoatexmeta.tex: Makefile
 	/bin/echo '\newcommand{\ivoaDocdatecode}{$(DOCDATE)}' | sed -e 's/-//g' >>$@
 	/bin/echo '\newcommand{\ivoaDoctype}{$(DOCTYPE)}' >>$@
 	/bin/echo '\newcommand{\ivoaDocname}{$(DOCNAME)}' >>$@
+ifneq ($(GITVERSION), )
+	/bin/echo '\vcsrevision{$(GITVERSION)$(GITDIRTY)}' >>$@
+endif
+ifneq ($(GITDATE), )
+	/bin/echo '\vcsdate{$(GITDATE)}' >>$@
+endif
 
 $(DOCNAME).html: $(DOCNAME).pdf ivoatex/tth-ivoa.xslt $(TTH) \
 		$(GENERATED_PNGS)


### PR DESCRIPTION
This is partially taken from [jdswinbank/vtp](https://github.com/jdswinbank/vtp/blob/master/Makefile); however I applied the change to the ivoatex repository instead of each individual document repository.

The SVN tags in the individual document repositories have no use anymore and should be removed.

Calling @msdemlei for a review. This should still work with SVN.