### PR TITLE
add .gitignore to ignore tth_C/tth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tth_C/tth


### PR DESCRIPTION
This means that when you build the html document (which in turn
builds tth) it doesn't look like your ivoatex submodule is modified.