### PR TITLE
Latex build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,13 @@ PYTHON?=python3
 #     XSLT processor
 #     C compiler
 #     GNU make (or another sufficiently powerful make)
-#     pdflatex
+#     texlive
 #     ghostscript (if you plan on postscript/pdf figures)
 #     zip
-#     librsvg2-bin (to teach convert to turn svg to pdf, the arch diagram)
-#  All of these are likely present on, e.g., a linux distribution,
-#  except for librsvg, which is part of the gnome svg toolkit.
-#  Hence, please commit both role_diagram.svg and role_diagram.pdf into
-#  your VCS.
+#     inkscape if you need an architecture diagram
+#     pdftk if you want to build draft pdfs with a watermark
+#  Since inkscape is a rather exotic dependency, please commit both 
+#  role_diagram.svg and role_diagram.pdf into your VCS for now.
 XSLTPROC = xsltproc
 XMLLINT = xmllint -noout
 PDFLATEX = pdflatex
@@ -61,6 +60,11 @@ $(DOCNAME).pdf: ivoatexmeta.tex $(SOURCES) $(FIGURES) $(VECTORFIGURES)
 forcetex:
 	$(PDFLATEX) $(DOCNAME)   # && $(PDFLATEX) $(DOCNAME) && $(PDFLATEX) $(DOCNAME)
 
+$(DOCNAME)-draft.pdf: $(DOCNAME).pdf draft-background.pdf
+	pdftk $< background draft-background.pdf output $@
+
+draft-background.pdf: ivoatex/draft-background.tex
+	pdflatex $<
 
 arxiv-upload: $(SOURCES) biblio $(FIGURES) $(VECTORFIGURES) ivoatexmeta.tex
 	mkdir -p stuff-for-arxiv/ivoatex

--- a/Makefile
+++ b/Makefile
@@ -225,5 +225,5 @@ ivoatex-installdist: $(IVOATEX_ARCHIVE)
 
 # re-gets the ivoa records from ADS
 docrepo.bib:
-	curl -o "$@" "http://adsabs.harvard.edu/cgi-bin/nph-abs_connect?db_key=ALL&warnings=YES&version=1&bibcode=%3F%3F%3F%3Fivoa.spec%0D%0A%3F%3F%3F%3Fivoa.rept&nr_to_return=1000&start_nr=1&data_type=BIBTEX&use_text=YES"
+	python3 fetch_from_ads.py
 	

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ $(DOCNAME).pdf: ivoatexmeta.tex $(SOURCES) $(FIGURES) $(VECTORFIGURES)
 
 
 forcetex:
-	$(PDFLATEX) $(DOCNAME)   # && $(PDFLATEX) $(DOCNAME) && $(PDFLATEX) $(DOCNAME)
+	make -W $(DOCNAME).tex $(DOCNAME).pdf
 
 $(DOCNAME)-draft.pdf: $(DOCNAME).pdf draft-background.pdf
 	pdftk $< background draft-background.pdf output $@

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,18 @@ PYTHON?=python3
 #     zip
 #     inkscape if you need an architecture diagram
 #     pdftk if you want to build draft pdfs with a watermark
+#     optionally, latexmk.
 #  Since inkscape is a rather exotic dependency, please commit both 
 #  role_diagram.svg and role_diagram.pdf into your VCS for now.
+
 XSLTPROC = xsltproc
 XMLLINT = xmllint -noout
-PDFLATEX = pdflatex
+LATEXMK_BANNER := $(shell latexmk --version 2> /dev/null)
+ifdef LATEXMK_BANNER
+	PDFLATEX = latexmk -pdf
+else
+	PDFLATEX = pdflatex
+endif
 CONVERT = convert
 ZIP = zip
 
@@ -55,7 +62,6 @@ GENERATED_PNGS = $(VECTORFIGURES:pdf=png)
 
 $(DOCNAME).pdf: ivoatexmeta.tex $(SOURCES) $(FIGURES) $(VECTORFIGURES)
 	$(PDFLATEX) $(DOCNAME)
-
 
 forcetex:
 	make -W $(DOCNAME).tex $(DOCNAME).pdf
@@ -116,10 +122,14 @@ $(DOCNAME).html: $(DOCNAME).pdf ivoatex/tth-ivoa.xslt $(TTH) \
 #		| tee debug.html \
 
 $(DOCNAME).bbl: $(DOCNAME).tex ivoatex/ivoabib.bib ivoatexmeta.tex
+ifdef LATEXMK_BANNER
+	$(PDFLATEX) -bibtex $(DOCNAME).tex
+else
 	-$(PDFLATEX) -interaction batchmode $(DOCNAME).tex
 	bibtex $(DOCNAME).aux
 	$(PDFLATEX) -interaction batchmode $(DOCNAME).tex 2>&1 >/dev/null
 	$(PDFLATEX) -interaction scrollmode $(DOCNAME).tex
+endif
 
 # We don't let the pdf depend on .bbl, as we don't want to run BibTeX
 # every time the TeX input is changed.  The idea is that when people do

--- a/draft-background.tex
+++ b/draft-background.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{tikz}
+\usepackage[a4paper,left=0.5cm]{geometry}
+\begin{document}
+\pagestyle{empty}
+\begin{tikzpicture}
+\pgftransformscale{2}
+\pgftransformrotate{90}
+\color{gray}
+\pgftext{\bfseries\sffamily DRAFT -- please do not distribute}
+\end{tikzpicture}
+\end{document}

--- a/fetch_from_ads.py
+++ b/fetch_from_ads.py
@@ -1,0 +1,60 @@
+"""
+A script to fetch the IVOA records from ADS using the ADS API.
+
+You'll need to get an ADS API key (see
+https://github.com/adsabs/adsabs-dev-api) to run this and put it into the
+environment variable ADS_TOKEN.
+
+If successful, it will write BibTeX to docrepo.bib (as needed by ivoatex).
+
+Copyright 2020, the GAVO project
+
+This is part of ivoatex, covered by the GPL.  See COPYING for details.
+"""
+
+import json
+import os
+from urllib import parse, request
+
+API_URL = "https://api.adsabs.harvard.edu/v1/"
+
+try:
+    ADS_TOKEN = os.environ["ADS_TOKEN"]
+except KeyError:
+    sys.exit("No ADS_TOKEN defined.  Get an ADS API key and put it there.")
+
+
+def do_api_request(_path, _payload=None, **arguments):
+    """returns the json-decoded result of an ADS request to path with
+    arguments.
+
+    path is relative to API_URL.
+    """
+    # Yeah, I know, I could save this with requests; but it'd be an
+    # extra dependency, and avoiding that is worth a few lines.
+    auth_header = {"Authorization": "Bearer:%s"%ADS_TOKEN}
+    req = request.Request(
+        API_URL+_path+"?"+parse.urlencode(arguments),
+        _payload,
+        auth_header)
+    f = request.urlopen(req)
+    return json.load(f)
+
+
+def main():
+    bibcode_recs = do_api_request("search/query/", 
+        q="bibstem:(ivoa.spec or ivoa.rept)",
+        rows="500",
+        fl="bibcode")
+    
+    bibtex_args = {
+        "bibcode": [r["bibcode"] for r in bibcode_recs["response"]["docs"]],}
+    bibtex_recs = do_api_request("export/bibtex",
+        _payload=json.dumps(bibtex_args).encode("ascii"))
+    with open("docrepo.bib", "w") as f:
+        f.write(bibtex_recs["export"])
+
+
+if __name__=="__main__":
+    main()
+# vi:sw=4:et:sta


### PR DESCRIPTION
This PR improves building a document in two ways:

(a) make forcetex now does what people expect in their CI code: it
rebuilds the document as if the TeX source had changed.  In contrast, up
to now the dependencies didn't get built with forcetex.

(b) If available, latexmk is now used to build the document.  That ought
to save a lot of the resons to run forcetex in the first place.