### PR TITLE
Adding a facility to build watermarked PDFs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,13 @@ PYTHON?=python3
 #     XSLT processor
 #     C compiler
 #     GNU make (or another sufficiently powerful make)
-#     pdflatex
+#     texlive
 #     ghostscript (if you plan on postscript/pdf figures)
 #     zip
-#     librsvg2-bin (to teach convert to turn svg to pdf, the arch diagram)
-#  All of these are likely present on, e.g., a linux distribution,
-#  except for librsvg, which is part of the gnome svg toolkit.
-#  Hence, please commit both role_diagram.svg and role_diagram.pdf into
-#  your VCS.
+#     inkscape if you need an architecture diagram
+#     pdftk if you want to build draft pdfs with a watermark
+#  Since inkscape is a rather exotic dependency, please commit both 
+#  role_diagram.svg and role_diagram.pdf into your VCS for now.
 XSLTPROC = xsltproc
 XMLLINT = xmllint -noout
 PDFLATEX = pdflatex
@@ -61,6 +60,11 @@ $(DOCNAME).pdf: ivoatexmeta.tex $(SOURCES) $(FIGURES) $(VECTORFIGURES)
 forcetex:
 	$(PDFLATEX) $(DOCNAME)   # && $(PDFLATEX) $(DOCNAME) && $(PDFLATEX) $(DOCNAME)
 
+$(DOCNAME)-draft.pdf: $(DOCNAME).pdf draft-background.pdf
+	pdftk $< background draft-background.pdf output $@
+
+draft-background.pdf: ivoatex/draft-background.tex
+	pdflatex $<
 
 arxiv-upload: $(SOURCES) biblio $(FIGURES) $(VECTORFIGURES) ivoatexmeta.tex
 	mkdir -p stuff-for-arxiv/ivoatex

--- a/draft-background.tex
+++ b/draft-background.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{tikz}
+\usepackage[a4paper,left=0.5cm]{geometry}
+\begin{document}
+\pagestyle{empty}
+\begin{tikzpicture}
+\pgftransformscale{2}
+\pgftransformrotate{90}
+\color{gray}
+\pgftext{\bfseries\sffamily DRAFT -- please do not distribute}
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
Run  "make mydocname-draft.pdf" to have a watermark, which is defined
in draft-background.tex.

This is mainly in response to requirements from people doing CI.