### PR TITLE
Add Makefile task `github-preview`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,10 +252,13 @@ $(GITHUB_WORKFLOWS):
 
 $(GITHUB_BUILD): $(GITHUB_WORKFLOWS) $(GITHUB_BUILD_TEMPLATE)
 	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_BUILD_TEMPLATE) > $@
+	@git add "$@"
 	@echo "* GitHub Workflow for PDF preview in PullRequest configured:\n      $@"
+	@echo '  => Run "git commit && git push" to enable GitHub PDF preview.'
 
 $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_PREVIEW_TEMPLATE) > $@
+	@git add "$@"
 	@echo "* GitHub Workflow for PDF preview at pushed commit configured:\n\
 	        $@\n\
 	  -----------------------------------------------------------------------\n\
@@ -265,6 +268,7 @@ $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 	    You can add it into your README.md to give an easy way to access\n\
 	    the PDF preview to your users.\n\
 	  -----------------------------------------------------------------------"
+	@echo '  => Run "git commit && git push" to enable GitHub PDF preview.'
 
 github-preview: $(GITHUB_BUILD) $(GITHUB_PREVIEW)
 	

--- a/Makefile
+++ b/Makefile
@@ -236,4 +236,36 @@ ivoatex-installdist: $(IVOATEX_ARCHIVE)
 # re-gets the ivoa records from ADS
 docrepo.bib:
 	python3 fetch_from_ads.py
+
+############# GitHub workflows configuration
+
+.PHONY: github-preview
+
+GITHUB_WORKFLOWS        = .github/workflows
+GITHUB_BUILD            = $(GITHUB_WORKFLOWS)/build.yml
+GITHUB_PREVIEW          = $(GITHUB_WORKFLOWS)/preview.yml
+GITHUB_BUILD_TEMPLATE   = ivoatex/github_workflow_build.yml.template
+GITHUB_PREVIEW_TEMPLATE = ivoatex/github_workflow_preview.yml.template
+
+$(GITHUB_WORKFLOWS):
+	@mkdir -p $@
+
+$(GITHUB_BUILD): $(GITHUB_WORKFLOWS) $(GITHUB_BUILD_TEMPLATE)
+	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_BUILD_TEMPLATE) > $@
+	@echo "* GitHub Workflow for PDF preview in PullRequest configured:\n      $@"
+
+$(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
+	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_PREVIEW_TEMPLATE) > $@
+	@echo "* GitHub Workflow for PDF preview at pushed commit configured:\n\
+	        $@\n\
+	  -----------------------------------------------------------------------\n\
+	    Clickable badge toward the generated PDF preview:\n\n\
+	        [![PDF-Preview](https://img.shields.io/badge/Preview-PDF-blue)]\
+	(../../releases/download/auto-pdf-preview/$(DOCNAME)-draft.pdf)\n\n\
+	    You can add it into your README.md to give an easy way to access\n\
+	    the PDF preview to your users.\n\
+	  -----------------------------------------------------------------------"
+
+github-preview: $(GITHUB_BUILD) $(GITHUB_PREVIEW)
 	
+

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,26 @@ Documents developed on github can be built like this::
 
 This produces the standards document ``ADQL.pdf``.
 
+Automatic PDF preview in GitHub
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To enable the automatic generation of a PDF preview in GitHub::
+
+   make github-preview
+   git add .github/workflows/build.yml .github/workflows/preview.yml
+   git commit -m 'Add/Update GH-Workflows for PDF Preview'
+   git push
+
+Once the generated files pushed on GitHub, this will produce a PDF preview
+after each pushed commit. This PDF will be available in the GitHub's
+Pre-Release ``Auto PDF Preview``.
+
+You may want to have a link toward this PDF preview. For this, you can add the
+clickable badge returned by the ``make`` command into your ``README.md``.
+
+A PDF preview is also generated at each update of a PullRequest. To get it,
+go on the page of your PullRequest, click on the tab ``Checks`` and then on
+``Artifacts``. This artifact will be automatically deleted after some time.
 
 Documentation
 -------------

--- a/github_workflow_build.yml.template
+++ b/github_workflow_build.yml.template
@@ -1,0 +1,39 @@
+name: Check the IVOA document
+
+env:
+  doc_name:
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - name: Checkout the repository
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    
+    - name: Setup dependencies
+      run: |
+        sudo apt update
+        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc
+      
+    - name: Build the document
+      run: make biblio forcetex
+      
+    - name: Check the output
+      run: |
+        test -f ${{ env.doc_name }}.pdf
+        test -f ${{ env.doc_name }}.bbl
+        
+    - name: Keep the PDF artefact 
+      uses: actions/upload-artifact@v1
+      with:
+        name: PDF Preview
+        path: ${{ env.doc_name }}.pdf

--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -1,0 +1,60 @@
+name: Update PDF Preview
+
+env:
+  doc_name:
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - name: Checkout the repository
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    
+    - name: Setup dependencies
+      run: |
+        sudo apt update
+        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc
+        sudo snap install pdftk
+    
+    - name: Build the document
+      run: make biblio ${{ env.doc_name }}-draft.pdf
+    
+    - name: Check the output
+      run: |
+        test -f ${{ env.doc_name }}-draft.pdf
+        test -f ${{ env.doc_name }}.bbl
+    
+    - name: Move the auto-pdf-preview tag
+      uses: weareyipyip/walking-tag-action@v1
+      with:
+        TAG_NAME: auto-pdf-preview
+        TAG_MESSAGE: |
+          Last commit taken into account for the automatically updated PDF preview of this IVOA document.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Update the PDF preview
+      uses: Xotl/cool-github-releases@v1
+      with:
+        mode: update
+        isPrerelease: true
+        tag_name: auto-pdf-preview
+        release_name: "Auto PDF Preview"
+        body_mrkdwn: |
+          This release aims to provide a PDF preview of the last commit applied on this repository.
+          It will be updated automatically after each merge of a PullRequest.
+          **DO NOT PUBLISH THIS PRE-RELEASE!**"
+          _Corresponding commit: ${{ github.sha }}_
+        assets: ${{ env.doc_name }}-draft.pdf
+        replace_assets: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This task will add 2 hidden files configuring the GitHub repository so that
a PDF preview is generated when a commit is pushed and when a PullRequest is
updated with commits. In the first case, the PDF preview will be published
in a GitHub Pre-Release (and will have a fix URL). In the second case, the PDF
will be accessible as a check artefact through the `Checks` tab of the
PullRequest.

The task `github-preview` will create two YAML files inside the directory
`.github/workflows/`:

  - `build.yml`   - workflow triggered at each PullRequest
  - `preview.yml` - workflow triggered at each pushed commit

Both files have to be commited and push to a remote GitHub repository to enable
the corresponding GitHub workflows.