### PR TITLE
Teaching tth to accept .svg as a valid image file for browsers.

### DIFF
--- a/tth-ivoa.xslt
+++ b/tth-ivoa.xslt
@@ -162,13 +162,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="img[@src='role_diagram.png']">
-    <!-- special handling for role diagrams for which we
-      know we have an svg -->
-    <img src="role_diagram.svg" alt="[IVOA architecture diagram]"
-      class="archdiag"/>
-  </xsl:template>
-
 	<xsl:template match="div[@id='titlepage']">
     <xsl:copy>
       <table cellspacing="0" cellpadding="0" width="450">

--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -28030,8 +28030,8 @@ char *arg;
 int epsftype;
 {
 #define NCONV 2
-#define NGTYPES 3
- char *gtype[NGTYPES]={"png","gif","jpg"};
+#define NGTYPES 4
+ char *gtype[NGTYPES]={"png","gif","jpg","svg"};
  char commandstr[150]={0};
  char filestr[150]={0};
  char filestr1[150]={0};


### PR DESCRIPTION
This, for one, make it stop call covert for role diagrams (no spurious
role_diagram.png any more, to issues with libsvg for convert).  This also
makes the ugly XSLT rule turning the png back into the svg superfluous.
A side effect: you can use svgs for other images in ivoatex documents.
I should advertise that in ivoatexDoc.

(I've asked tth upstream to accept that diff, too, so we don't diverge from them).