### PR TITLE
Gung-ho definition of nolinkurl

### DIFF
--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -93,9 +93,10 @@
 \newenvironment{lstlisting}[1][plain]
   {\special{html:<div keyvals="#1">}\tthverbatim{lstlisting}}
   {\special{html:</div>}}
-
-\newcommand{\nolinkurl}[1]{
-	\special{html:<span class='nolinkurl'>}#1\special{html:</span>}}
+ 
+\def\nolinkurl#1{\special{html:<span class="nolinkurl">}%
+  \verb|#1|%
+  \special{html:<span class="nolinkurl">}}
 
 \newenvironment{bigdescription}{%
     \begin{html}<div class="bigdescription">\end{html}


### PR DESCRIPTION
I should have defined it like this from the start, but I didn't dare try it because TeX would immediately reject such a thing (you need to fix catcodes before parsing the argument).  This even works with matched-up braces...  amazing.

This ought to fix the bug underlying https://github.com/ivoa-std/ConeSearch/pull/49 and obviate the need for the PR.

(Where I'd say we could still apply the PR, as the formatting improvements are probably worth it)