### PR TITLE
Removing IVOA standards and ADS-published documents from ivoabib.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@ Version 1.2 (unreleased)
 
   * New VO-DML translator for the generator.
 
+	* Removed legacy entries for IVOA standards from ivoabib.bib.  Use records
+	  from docrepo.bib instead.
+	
   * Minor fixes (e.g., escaping in schema snippets, &-less bibanchors,
     titles in HTML output).
 

--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -471,7 +471,7 @@ booktitle = {Astronomical Data Analysis Software and Systems XV},
 }
 
 @Misc{note:ADQL2Err1,
-  author =       {Marco Molinaro},
+  author =       {Dave Morris},
   title =        {ADQL 2.0 Erratum 1: White Space Clarification},
   howpublished = {{IVOA Erratum, 2018-02-22}},
   year =         {2018},

--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -1,7 +1,11 @@
-NOTE: Do not use the records for IVOA standards (i.e., recommendations) from
-here.  They only are here for legacy documents.
+PLEASE NOTE: this file used to contain records for IVOA standards,
+mostly with an std: prefix (e.g., "std:TAP").  These records were stale,
+did not contain DOIs or bibcodes, and were otherwise so undesirable that
+we purged them 2020-11.
 
-Instead, take the version-sharp, ADS-connected records from docrepo.bib.  See also ivoatexDoc, sect. 3.3.2.
+If you have documents using these references, please update them, using the
+version-sharp, ADS-connected records from docrepo.bib.  See also 
+ivoatexDoc 1.2, sect. 3.3.2.
 
 
 @Misc{std:FITS,

--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -4,26 +4,6 @@ here.  They only are here for legacy documents.
 Instead, take the version-sharp, ADS-connected records from docrepo.bib.  See also ivoatexDoc, sect. 3.3.2.
 
 
-% [1] R. Hanisch, Resource Metadata for the Virtual Observatory , http://www.ivoa.net/Documents/latest/RM.html
-@Misc{std:RM,
-  editor =       {R. Hanisch},
-  author =       {Robert Hanisch and {IVOA Resource Registry Working Group} and {NVO Metadata Working Group}},
-  title =        {Resource Metadata for the Virtual Observatory},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2007},
-  url =          {http://www.ivoa.net/documents/latest/RM.html}
-}
-
-% [2] R. Hanisch, M. Dolensky, M. Leoni, Document Standards Management: Guidelines and Procedure , http://www.ivoa.net/documents/latest/DocStdProc.html
-@Misc{std:DocSTDProc,
-  author =       {Bob Hanisch and Markus Dolensky and Marco Leoni},
-  title =        {Document Standards Management: Guidelines and
-                  Procedure, Version 1.0},
-  howpublished = {{IVOA Note}},
-  year =         2004,
-  url =          {http://www.ivoa.net/documents/latest/DocStdProc.html}
-}
-
 @Misc{std:FITS,
    author = {{Hanisch}, R.~J. and {Farris}, A. and {Greisen}, E.~W. and {Pence}, 
 W.~D. and 
@@ -59,61 +39,6 @@ MISCELLANEOUS, ASTRONOMICAL DATABASES: MISCELLANEOUS},
   url = {https://tools.ietf.org/html/rfc4180}
 }
 
-@Misc{std:VOID,
-  author =       {Raymond Plante and Tony Linde and Roy Williams and Keith Noddle},
-  title =        {{IVOA} Identifiers, Version 1.03},
-  howpublished = {{IVOA Recommendation}},
-  month =        mar,
-  year =         2007,
-  url =          {http://www.ivoa.net/documents/REC/Identifiers/Identifiers-20070302.html}
-}
-
-@Misc{std:VOID2,
-  author =       {Markus Demleitner and Raymond Plante and Tony Linde and Roy Williams and Keith Noddle},
-  title =        {{IVOA} Identifiers, Version 2},
-  howpublished = {{IVOA Recommendation}},
-  month =        jul,
-  year =         2015,
-  url =          {http://www.ivoa.net/documents/IVOAIdentifiers/20160523/}
-}
-
-
-@Misc{std:VOR,
-  author =       {Raymond Plante and Kevin Benson and Matthew Graham and Gretchen Greene and Paul Harrison and Gerard Lemson and Tony Linde and Guy Rixon and Aurélien Stébé},
-  title =        {{VOResource}: an {XML} Encoding Schema for Resource Metadata
-Version 1.03},
-  howpublished = {{IVOA Recommendation}},
-  month =        feb,
-  year =         2008,
-  url =          {http://www.ivoa.net/documents/REC/ReR/VOResource-20080222.html},
-}
-
-@Misc{std:docSTD,
-  author =       {R. J. Hanisch and C. Arviset and F. Genova and B. Rino},
-  title =        {{IVOA} Document Standards, Version 1.2},
-  howpublished = {{IVOA Recommendation}},
-  year =         2010,
-  url =          {http://www.ivoa.net/documents/DocStd/}
-}
-
-@Misc{std:UWS,
-  author =       {Paul Harrison and Guy Rixon},
-  title =        {Universal Worker Service Pattern, Version 1.0},
-  howpublished = {{IVOA Recommendation}},
-  month =        oct,
-  year =         2010,
-  url =          {http://www.ivoa.net/documents/UWS/20101010/}
-}
-
-@Misc{std:UWS11,
-  author =       {Paul Harrison and Guy Rixon},
-  title =        {Universal Worker Service Pattern, Version 1.1},
-  howpublished = {{IVOA Recommendation}},
-  month =        oct,
-  year =         2016,
-  url =          {http://www.ivoa.net/documents/UWS}
-}
-
 @misc{note:UWSRegExt,
   author={Brian Major and Markus Demleitner and Patrick Dowler},
   editor = {Brian Major},
@@ -123,63 +48,6 @@ Version 1.03},
   month=aug,
   year=2018,
   url={{http://ivoa.net/documents/Notes/UWSRegExt}}
-}
-
-@Misc{std:TAP,
-  author =       {Patrick Dowler and Guy Rixon and Doug Tody},
-  title =        {Table Access Protocol Version 1.0},
-  howpublished = {{IVOA Recommendation}},
-  month =        mar,
-  year =         2010,
-  url =          {http://www.ivoa.net/documents/TAP}
-}
-
-@Misc{std:TAP-20100327,
-  author =       {Patrick Dowler and Guy Rixon and Doug Tody},
-  title =        {Table Access Protocol Version 1.0, 2010-03-27},
-  howpublished = {{IVOA Recommendation}},
-  month =        mar,
-  year =         2010,
-  url =          {http://www.ivoa.net/documents/TAP/20100327}
-}
-
-@Misc{std:DALREGEXT,
-  author =       {Raymond Plante and Jesus Delago and Paul Harrison and 
-  	Doug Tody},
-  title =        {{SimpleDALRegExt}: Describing Simple Data Access Services,
-  	Version 1.0},
-  howpublished = {{IVOA Proposed Recommendation}},
-  month =        may,
-  year =         2012,
-  url =          {http://www.ivoa.net/documents/SimpleDALRegExt/20120517/PR-SimpleDALRegExt-20120517.html}
-}
-
-@Misc{std:VODS11,
-	author = {Raymond Plante and Aurélien Stébé and Kevin Benson and Patrick Dowler and Matthew Graham and Gretchen Greene and Paul Harrison and Gerard Lemson and Tony Linde and Guy Rixon},
-	title = {{VODataService}: a {VOResource} Schema Extension for Describing Collections and Services Version 1.1},
-  howpublished = {{IVOA Recommendation}},
-  month =        dec,
-  year =         2010,
-  url =          {http://www.ivoa.net/documents/VODataService/}
-}
-
-
-@Misc{std:DALI,
-	author =       {Patrick Dowler and Markus Demleitner and Mark Taylor and Doug Tody},
-	title =        {Data Access Layer Interface, Version 1.0},
-	howpublished = {{IVOA Recommendation}},
-  month =        nov,
-  year =         2013,
-  url =          {http://www.ivoa.net/documents/DALI/20131129/}
-}
-
-@Misc{std:DALI11,
-	author =       {Patrick Dowler and Markus Demleitner and Mark Taylor and Doug Tody},
-	title =        {Data Access Layer Interface, Version 1.1},
-	howpublished = {{IVOA Recommendation}},
-  month =        may,
-  year =         2017,
-  url =          {http://www.ivoa.net/documents/DALI}
 }
 
 
@@ -248,79 +116,6 @@ Version 1.03},
        Year = {2005}
 }
 
-@Misc{std:VOEVENT,
-  date-added	= {2007-11-19 17:44:04 +0000},
-  date-modified	= {2007-11-19 17:46:11 +0000},
-  editor	= {Rob Seaman and Roy Williams},
-  howpublished	= {{IVOA Recommendation}},
-  keywords	= {ivoa; vocabularies; standard},
-  title		= {Sky Event Reporting Metadata ({VOEvent})},
-  url		= {http://www.ivoa.net/documents/latest/VOEvent.html},
-  year		= {2006}
-}
-
-@Misc{std:VOEVENT2,
-  title =        {Sky Event Reporting Metadata, Version 2.0},
-  author =       {Rob Seaman and Roy Williams and Alasdair Allan and Scott Barthelmy and Joshua Bloom and John Brewer and Robert Denny and Mike Fitzpatrick and Matthew Graham and Norman Gray and Frederic Hessman and Szabolcs Marka and Arnold Rots and Tom Vestrand and Przemyslaw Wozniak},
-  howpublished = {{IVOA Recommendation}},
-  month =        jul,
-  year =         2011,
-  url =          {http://www.ivoa.net/documents/VOEvent/20110711/}
-}
-
-@Misc{std:VOEventRegExt,
-  title        = "{VOEventRegExt: an XML encoding schema for resource metadata for collections of events, version 1.0}",
-  author       = {Matthew Graham and Roy Williams and John Swinbank and Rob Seaman and Alasdair Allan and Ray Plante},
-  editor       = {Matthew Graham},
-  howpublished = {{IVOA Working Draft}},
-  year         = 2014,
-  url          = {http://www.ivoa.net/documents/VOEventRegExt/index.html}
-}
-
-@misc{std:UCD,
-  author	= {S{\'e}bastien Derriere and Norman Gray and Robert Mann and
-		  Preite Martinez, Andrea and Jonathan McDowell and Thomas
-		  McGlynn and Fran{\,c}ois Ochsenbein and Pedro Osuna and Guy
-		  Rixon and Roy Williams},
-  editor = {S{\'e}bastien Derriere and Andrea Preite Martinez and Roy Williams},
-  date-added	= {2005-07-05 09:45:44 +0100},
-  date-modified	= {2007-11-20 17:05:29 +0000},
-  howpublished  = {{IVOA Recommendation}},
-  keywords	= {standard; ivoa},
-  lastchecked	= {February 2008},
-  title		= {{UCD (Unified Content Descriptor)} -- Moving to {UCD1+}},
-  url		= {http://www.ivoa.net/documents/latest/UCD.html},
-  year		= {2004}
-}
-
-
-@misc{std:STDREGEXT,
-  author =       {Paul Harrison and Douglas Burke and Ray Plante and Guy Rixon and Dave Morris},
-  title =        {{StandardsRegExt}: a {VOResource} Schema Extension for Describing {IVOA} Standards, Version 1.0},
-  howpublished = {{IVOA Recommendation}},
-  month =        may,
-  year =         2012,
-  url =          {http://www.ivoa.net/documents/StandardsRegExt/20120508/REC-StandardsRegExt-1.0-20120508.html},
-}
-
-
-@misc{std:TAPREGEXT,
-	author = {Markus Demleitner and Patrick Dowler and Ray Plante and Guy Rixon and Mark Taylor},
-	title = {{TAPRegExt}: a {VOResource} Schema Extension for Describing {TAP} Services, Version 1.0},
-  howpublished = {{IVOA Recommendation}},
-  month =        aug,
-  year =         2012,
-  url =          {http://www.ivoa.net/documents/TAPRegExt},
-}
-
-@misc{std:TAPREGEXT-20120827,
-	author = {Markus Demleitner and Patrick Dowler and Ray Plante and Guy Rixon and Mark Taylor},
-	title = {{TAPRegExt}: a {VOResource} Schema Extension for Describing {TAP} Services, Version 1.0, 2012-08-27},
-  howpublished = {{IVOA Recommendation}},
-  month =        aug,
-  year =         2012,
-  url =          {http://www.ivoa.net/documents/TAPRegExt/20120827/index.html},
-}
 
 @webpage{IVOAWIKI,
   url = {http://wiki.ivoa.net/twiki/bin/view/IVOA/WebHome},
@@ -379,99 +174,6 @@ Version 1.03},
 }
 
 
-@Misc{std:SIAv2,
-   author = {Patrick Dowler and Doug Tody and Francois Bonnarel},
-   title = {IVOA Simple Image Access, Version 2.0},
-   howpublished = {IVOA Recommendation 23 December 2015},
-   year = 2015,
-   month = dec,
-   editor = {Patrick Dowler and Francois Bonnarel},
-}
-
-@Misc{std:SIAP,
-  editor =       {Paul Harrison},
-  author =       {Doug Tody and Ray Plante},
-  title =        {Simple Image Access Specification},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2009},
-  url =          {http://www.ivoa.net/documents/latest/SIA.html}
-}
-@Misc{std:SCS,
-  editor =       {Raymond Plante},
-  author =       {Roy Williams and Robert Hanisch and Alex Szalay and Raymond Plante},
-  title =        {Simple Cone Search - Version 1.03},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2008},
-  url =          {http://www.ivoa.net/documents/latest/ConeSearch.html}
-}
-
-@Misc{std:SSAP,
-  editor =       {Doug Tody},
-  author =       {Doug Tody and Markus Dolensky and Jonathan {McDowell}
-  	and Fran\cois Bonnarel and Tamas Budavari and Ivan Busko and
-  	Alberto Micol and Pedro Osuna and Jesus Salgado and Petr Skoda
-  	and Randy Thompson and Franceso Valdes},
-  title =        {Simple Spectral Access Protocol Version 1.1},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2012},
-  url =          {http://www.ivoa.net/documents/SSA/20120210/REC-SSA-1.1-20120210.htm}
-
-}
-
-@Misc{std:ADQL,
-  editor =       {Pedro Osuna and I{\~n}aki Ortiz},
-  author =       {I{\~n}aki Ortiz and Jeff Lusted and Pat Dowler and
-Alexander Szalay and Yuji Shirasaki and Maria A. Nieto-Santisteban and Masatoshi Ohishi and William O'Mullane and Pedro Osuna and the VOQL-TEG and the VOQL Working Group},
-  title =        {{IVOA} Astronomical Data Query Language},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2008},
-  url =          {http://www.ivoa.net/documents/latest/ADQL.html}
-}
-
-@Misc{std:ADQL-20081030,
-  editor =       {Pedro Osuna and I{\~n}aki Ortiz},
-  author =       {I{\~n}aki Ortiz and Jeff Lusted and Pat Dowler and Alexander Szalay and Yuji Shirasaki and Maria A. Nieto-Santisteba and Masatoshi Ohishi and William O'Mullane and Pedro Osuna and the VOQL-TEG and the VOQL Working Group},
-  title =        {{IVOA} Astronomical Data Query Language, Version 2.0, 2008-10-30},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2008},
-  url =          {http://www.ivoa.net/documents/cover/ADQL-20081030.html}
-}
-
-@Misc{std:VOSPACE,
-  editor =       {Matthew Graham and Brian Major},
-  author =       {Matthew Graham and Dave Morris and Guy Rixon and Pat Dowler and André Schaaff and Doug Tody and Brian Major},
-  title =        {{VOSpace} specification - Version 2.1},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2018},
-  url =          {http://www.ivoa.net/documents/VOSpace/}
-}
-
-@Misc{std:RI1,
-  editor =       {Kevin Benson and Ray Plante},
-  author =       {Kevin Benson and Ray Plante and Elizabeth Auden and Matthew Graham and Gretchen Greene and Martin Hill and Tony Linde and Dave Morris and Wil O'Mullane and Guy Rixon and Aurélien Stébé and Kona Andrews},
-  title =        {{IVOA} Registry Interfaces Version 1.0},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2009},
-  url =          {http://www.ivoa.net/documents/RegistryInterface/}
-}
-
-@Misc{std:RI2,
-  editor =       {Kevin Benson and Ray Plante},
-  author =       {Kevin Benson and Ray Plante and Elizabeth Auden and Matthew Graham and Gretchen Greene and Martin Hill and Tony Linde and Dave Morris and Wil O'Mullane and Guy Rixon and Aurélien Stébé and Kona Andrews},
-  title =        {{IVOA} Registry Interfaces Version 2.0},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2015},
-  url =          {http://www.ivoa.net/documents/RegistryInterface/}
-}
-
-@Misc{std:STC,
-  author =       {Arnold Rots},
-  title =        {Space-Time Coordinate Metadata for the Virtual Observatory},
-  howpublished = {{IVOA Recommendation}},
-  year =         {2007},
-  url =          {http://www.ivoa.net/documents/latest/STC.html}
-}
-
 @Misc{std:STCS,
   editor =       {Arnold Rots},
   author =       {Arnold Rots and Markus Demleitner and Patrick Dowler},
@@ -490,7 +192,6 @@ Version 1.00},
   year =         {2005},
   url =          {http://ivoa.net/documents/latest/STC-X.html}
 }
-
 
 @misc{std:OAIPMH,
 	key = {Open Archives Initiative},
@@ -526,125 +227,6 @@ Dave Winer
   author={Paul Harrison},
   title={VOCEA - An XML schema for Registering CEA},
   }
-
-@Misc{std:SSOAUTH,
-  author={{Grid and Web Services Working Group}},
-  editor={Guy Rixon and Matthew Graham},
-  title={{IVOA} Single-Sign-On Profile: Authentication Mechanisms Version 1.01},
-  year=2008,
-  url= {http://www.ivoa.net/documents/latest/SSOAuthMech.html}
-}
-
-@Misc{std:SSOAUTH2,
-  author       = {Brian Major and Guy Rixon and Andr\`e Schaaff and Giuliano Taffoni},
-  editor       = {Giuliano Taffoni},
-  title        = {{IVOA} Single-Sign-On Profile: Authentication Mechanisms, Version 2.0},
-  year         = 2016,
-  month        = sep,
-  url          = {http://www.ivoa.net/documents/SSO/20160930/PR-SSOAuthMech-2.0-20160930.html},
-  howpublished = {{IVOA Proposed Recommendation}}
-}
-
-@Misc{std:CDP,
-        author={Matthew Graham and Raymond Plante and Guy Rixon and Giuliano Taffoni},
-        editor={Raymond Plante and Matthew Graham},
-        title={{IVOA} Credential Delegation Protocol},
-        year=2010,
-        url={http://ivoa.net/Documents/CredentialDelegation/20100218/}
-}
-
-@Misc{std:VOSI,
-	author={{Grid and Web Services Working Group}},
-	editor={Matthew Graham and Guy Rixon and Patrick Dowler and Brian Major},
-	title={{IVOA} Support Interfaces Version 1.1},
-	year=2017,
-	url={http://www.ivoa.net/documents/VOSI/index.html}
-}
-
-@Misc{std:VOSI11,
-	author={{Grid and Web Services Working Group}},
-	editor={Matthew Graham and Guy Rixon and Patrick Dowler and Brian
-Major},
-	title={{IVOA} Support Interfaces Version 1.1},
-	year=2017,
-	url={http://www.ivoa.net/documents/VOSI/20170524/index.html}
-}
-
-@Misc{std:VOUNIT,
-	author={Markus Demleitner and Sebastien Derriere and Norman Gray and Mireille Louys
-		and Francois Ochsenbein},
-	editor={Sebastien Derriere and Norman Gray},
-	howpublished={{IVOA Recommendation}},
-	title={Units in the {VO}, Version 1.0},
-	year=2014,
-	url={http://www.ivoa.net/documents/VOUnits/index.html}
-}
-
-@Misc{std:OBSCORE,
-	author={Mireille Louys and Francois Bonnarel and David Schade and 
-		Patrick Dowler and Alberto Micol and Daniel Durand and Doug Tody 
-		and Laurent Michel and Jesus Salgado and Igor Chilingarian 
-		and Bruno Rino and Juan de Dios Santander and Petr Skoda},
-	editor={Doug Tody and Alberto Micol and Daniel Durand and Mireille Louys},
-	howpublished={{IVOA Recommendation}},
-	title={Observation Data Model Core Components and its Implementation
-		in the {Table Access Protocol}, Version 1.0},
-	year=2011,
-	url={http://www.ivoa.net/documents/ObsCore/20111028/REC-ObsCore-v1.0-20111028.pdf}
-}
-
-@Misc{std:SDM,
-	author={Jonathan McDowell and Jesus Salgado and Carlos Rodrigo Blanco and Pedro Osuna and Doug Tody and Enrique Solano and Joe Mazzarella and Raffaele D'Abrusco and Mireille Louys and Tamas Budavari and Markus Dolensky and Inga Kamp and Kelly McCusker and Pavlos Protopapas and Arnold Rots and Randy Thompson and Frank Valdes and Petr Skoda and Bruno Rino and Jim Cant and Omar Laurino},
-	editor={Jonathan {McDowell} and Doug Tody},
-	howpublished={{IVOA Recommendation}},
-	title={{IVOA} Spectrum Data Model, Version 1.1},
-	year=2011,
-	url={http://www.ivoa.net/documents/SpectrumDM/}
-}
-
-
-@Misc{std:MOC,
-	author={Thomas Boch and Tom Donaldson and Daniel Durand and Pierre Fernique
-		and Wil O'Mullane and Martin Reinecke and Mark Taylor},
-	editor={Pierre Fernique},
-	howpublished={{IVOA Working Draft}},
-	title={{MOC} -- {HEALPix} Multi-Order Coverage map},
-	year=2013,
-	url={http://www.ivoa.net/documents/MOC/}
-}
-
-
-@Misc{std:RegTAP,
-	author={Markus Demleitner and Paul Harrison and Marco Molinaro and 
-		Gretchen Greene and Theresa Dower and Menelaos Perdikeas},
-	editor={Markus Demleitner},
-	howpublished={{IVOA Working Draft}},
-	title={{IVOA} Registry Relational Schema},
-	year=2013,
-	url={http://www.ivoa.net/documents/RegTAP/},
-}
-
-@Misc{std:DataLink,
-        author={Patrick Dowler and Francois Bonnarel and Laurent Michel and Markus Demleitner},
-        editor={Patrick Dowler},
-        howpublished={IVOA Recommendation 17 June 2015},
-        title={{IVOA} DataLink},
-        year=2015,
-        month=jun,
-        url={http://www.ivoa.net/documents/DataLink/}
-}
-
-@Misc{std:VOTABLE,
-	author={Francois Ochsenbein and Roy Williams and Clive Davenhall and Markus Demleitner and Daniel Durand and Pierre Fernique and David Giaretta and Robert Hanisch and Tom McGlynn and Alex Szalay and Mark Taylor and Andreas Wicenec},
-	editor={Francois Ochsenbein and Mark Taylor},
-	howpublished={{IVOA Recommendation}},
-	title={{VOTable} Format Definition, Version 1.3},
-	year=2013,
-	month=sep,
-	day=20,
-	url={http://www.ivoa.net/documents/VOTable/},
-}
-
 
 @Misc{std:iso8601,
   author={{International Organization for Standardization}},
@@ -870,37 +452,6 @@ booktitle = {Astronomical Data Analysis Software and Systems XV},
 		Digital object identifier system},
 	Url = {http://www.doi.org/idf-members/ISO\_Standard/ISO\_263234\_English\_Final.pdf}}
 
-@misc{note:VOARCH,
-	year=2010,
-	month=nov,
-	url={http://www.ivoa.net/documents/Notes/IVOAArchitecture},
-	author={Christophe Arviset and Severin Gaudet and the {IVOA} Technical Coordination Group},
-	editor = {Christophe Arviset},
-	title = {{IVOA} Architecture},
-	version = {1.0},
-	howpublished = {{IVOA Note}}}
-
-@misc{note:schemaversioning,
-	year=2016,
-	month=sep,
-	url={{http://ivoa.net/documents/Notes/XMLVers}},
-	author={Paul Harrison and Markus Demleitner and Brian Major and Pat Dowler},
-	editor = {Paul Harrison},
-	title = {{XML} Schema Versioning Policies},
-	version = {1.0},
-	howpublished = {{IVOA} Proposed Endorsed Note}
-}
-
-@misc{note:DataCollect,
-	year=2016,
-	month=jan,
-	url={{http://www.ivoa.net/documents/Notes/DataCollect}},
-	author={Markus Demleitner and Mark Taylor},
-	editor = {Markus Demleitner},
-	title = {Discovering Data Collections Within Services},
-	version = {1.0},
-	howpublished = {{IVOA Note}}}
-
 @Misc{note:utypeusage,
   author =       {Matthew Graham and Markus Demleitner and Patrick Dowler and Pierre Fernique and Omar Laurino and Gerard Lemson and Mireille Louys and Jesus Salgado},
   title =        {{UTypes}: current usages and practices in the {IVOA}},
@@ -919,24 +470,13 @@ booktitle = {Astronomical Data Analysis Software and Systems XV},
   url =          {http://www.ivoa.net/documents/Notes/URIFragments},
 }
 
-
-@Misc{note:TAPNotes,
-  author =       {Markus Demleitner and Paul Harrison and Mark Taylor},
-  title =        {{TAP} {I}mplementation {N}otes, {V}ersion 1.0},
-  howpublished = {{IVOA Note}},
-  year =         {2013},
-  month = 	     {December},
-  url =          {http://ivoa.net/documents/Notes/TAPNotes}
-}
-
 @Misc{note:ADQL2Err1,
   author =       {Marco Molinaro},
-  title =        {ADQL 2.0 Erratum 1: remove nonterminal separator grammar token},
-  howpublished = {{IVOA Note}},
-  year =         {2014},
-  month = 	     {dec},
-  day = 	     {22},
-  url =          {}
+  title =        {ADQL 2.0 Erratum 1: White Space Clarification},
+  howpublished = {{IVOA Erratum, 2018-02-22}},
+  year =         {2018},
+  month = 	     {feb},
+  url =          {https://wiki.ivoa.net/twiki/bin/view/IVOA/ADQL-2_0-Err-1}
 }
 
 
@@ -956,18 +496,20 @@ booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
 }
 
 @ARTICLE{paper:regclient,
-   author = {{Demleitner}, M. and {Harrison}, P. and {Taylor}, M. and {Normand}, J.
-	},
-    title = "{Client Interfaces to the Virtual Observatory Registry}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1502.01186},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-     year = 2015,
-    month = feb,
-   adsurl = {http://ads.ari.uni-heidelberg.de/abs/2015arXiv150201186D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, M. and {Harrison}, P. and {Taylor}, M. and {Normand}, J.},
+        title = "{Client interfaces to the Virtual Observatory Registry}",
+      journal = {Astronomy and Computing},
+     keywords = {Virtual Observatory, Registry, Standards, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2015,
+        month = apr,
+       volume = {10},
+        pages = {88-98},
+          doi = {10.1016/j.ascom.2015.01.008},
+archivePrefix = {arXiv},
+       eprint = {1502.01186},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015A&C....10...88D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{soft:Splat,
@@ -1027,16 +569,6 @@ archivePrefix = "ascl",
   howpublished = {{IETF BCP 47}},
   year = 2009,
   url = {https://tools.ietf.org/html/bcp47}
-}
-
-@Misc{note:votstc,
-  author =       {Markus Demleitner and François Ochsenbein and Johnathan
-  	McDowell and Arnold Rots},
-  title =        {Referencing {STC} in VOTable, Version 2.0},
-  howpublished = {{IVOA Note}},
-  year =         {2010},
-  month = 	     {June},
-  url =          {http://ivoa.net/documents/Notes/VOTableSTC}
 }
 
 @Misc{note:tsdisco,


### PR DESCRIPTION
This will *break existing documents* (which is why I've left these records in so far).  

On the other hand, these documents probably should have moved to taking the references from docrepo.bib anyway.  With this change, they will note that.  This will also address recurring trouble as exhibited last in Issue #25.

Since this is document-breaking, I will only merge this if I have two positive review and nobody opposing.