### PR TITLE
Updating VO architecture reference in the document template.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,9 @@ Version 1.2 (unreleased)
   * New VO-DML translator for the generator.
 
 	* Removed legacy entries for IVOA standards from ivoabib.bib.  Use records
-	  from docrepo.bib instead.
+	  from docrepo.bib instead.  In particular: note:VOARCH in the role
+	  diagram caption needs to become 2010ivoa.rept.1123 (until the
+	  arch note is updated).
 	
   * Minor fixes (e.g., escaping in schema snippets, &-less bibanchors,
     titles in HTML output).

--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,7 @@ Version 1.2 (unreleased)
 
 	* Removed legacy entries for IVOA standards from ivoabib.bib.  Use records
 	  from docrepo.bib instead.  In particular: note:VOARCH in the role
-	  diagram caption needs to become 2010ivoa.rept.1123 (until the
+	  diagram caption needs to become 2010ivoa.rept.1123A (until the
 	  arch note is updated).
 	
   * Minor fixes (e.g., escaping in schema snippets, &-less bibanchors,

--- a/document.template
+++ b/document.template
@@ -61,7 +61,7 @@ infrastructure that enable VO applications.
 \end{figure}
 
 Fig.~\ref{fig:archdiag} shows the role this document plays within the
-IVOA architecture \citep{note:VOARCH}.
+IVOA architecture \citep{2010ivoa.rept.1123}.
 
 ???? and so on, LaTeX as you know and love it. ????
 


### PR DESCRIPTION
Ouch: the template cited the now-deleted note:VOARCH bibitem.

Regrettably, this means essentially all documents will need to change
note:VOARCH to 2010ivoa.rept.1123 in the role diagram caption.