### PR TITLE
 More gracefully deal with submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ clean:
 	rm -f arxiv-upload.tar.gz
 	rm -f $(GENERATED_PNGS)
 
+update:
+	@echo "*** updating ivoatex from github"
+	git submodule update --remote
+
 .FORCE:
 
 gitmeta.tex: .FORCE
@@ -271,4 +275,4 @@ $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 	@echo '  => Run "git commit && git push" to enable GitHub PDF preview.'
 
 github-preview: $(GITHUB_BUILD) $(GITHUB_PREVIEW)
-	
+

--- a/Makefile.template
+++ b/Makefile.template
@@ -31,4 +31,9 @@ VECTORFIGURES =
 # Additional files to distribute (e.g., CSS, schema files, examples...)
 AUX_FILES = 
 
-include ivoatex/Makefile
+-include ivoatex/Makefile
+
+ivoatex/Makefile:
+	@echo "*** ivoatex submodule not found.  Initialising submodules."
+	@echo
+	git submodule update --init

--- a/tth-ivoa.xslt
+++ b/tth-ivoa.xslt
@@ -148,6 +148,7 @@
 				  width: 90%;
           margin-left: auto;
           margin-right: auto;
+          max-width: 19cm;
         }
 
         ul.authors, ul.previousversions, ul.editors {
@@ -155,6 +156,10 @@
         	padding-left: 0pt;
         	margin-top: 2pt;
         	margin-bottom: 2pt;
+        }
+
+        body div {
+        	max-width: 21cm;
         }
 			</xsl:text></style>
 
@@ -460,7 +465,17 @@
     </xsl:element>
   </xsl:template>
 
-	<!-- tth has given up detecting Ps in TeX source and hacks in
+	<!-- I want to style the role diagram; ideally, we'd add a class
+		through LaTeX, but TTH doesn't have a straightforward facility
+		for doing this.  Hence, I'm adding a class manually. -->
+  <xsl:template match="img[@src='role_diagram.svg']">
+  	<xsl:copy>
+  		<xsl:attribute name="class">archdiag</xsl:attribute>
+  		<xsl:apply-templates select="@*|node()"/>
+  	</xsl:copy>
+  </xsl:template>
+
+	<!-- tth has given up detecting p elements in TeX source and hacks in
 	     div class="p" elements as paragraph separators.  These
 	     are potentially very confusing to browsers.  We hence 
 	     replace them with hopefully less confusing constructs -->


### PR DESCRIPTION
This PR does two things:
    
(a) it changes the makefile template so that the ivoatex submodule
(and potentially any others) will automatically be initialised
if people forgot to do the recurse-submodules (which ought to address
issue #27).

(b) it adds an "update" target to the ivoatex makefile so people can
say "make update" now and then to fetch the latest ivoatex.

A review by people who've thought more about git submodules than I have
would be highly appreciated.