### PR TITLE
Fit archdiag boxes to text width

### DIFF
--- a/make-archdiag.xslt
+++ b/make-archdiag.xslt
@@ -85,6 +85,33 @@ want.
 	<svg  version="2.0"
 		width="800" height="600">
 		<defs>
+			<script type="text/javascript">
+			function adjustBoxWidthsForClass(cls) {
+				var recs = document.getElementsByClassName(cls);
+				for (var index in recs) {
+					if (!recs[index].nextSibling || !recs[index].nextSibling.getBBox) {
+						// for some reason we have a 'rec' box not followed by text;
+						// let's skip this for now an see if this bites someone.
+						continue;
+					}
+					var bbox = recs[index].nextSibling.getBBox();
+					var newWidth = bbox.width+6;
+					recs[index].width.baseVal.value = newWidth;
+					recs[index].x.baseVal.value += (90-newWidth)/2;
+				}
+			}
+
+			function adjustBoxWidths() {
+				// Regrettably, SVG doesn't seem to have a facility to bboxes
+				// around text.  We fake this here using javascript, to be
+				// called when the text is rendered.
+				adjustBoxWidthsForClass('rec');
+				adjustBoxWidthsForClass('prerec');
+			}
+
+			window.addEventListener("load", adjustBoxWidths, false);
+			</script>
+
 			<style type="text/css">
 				@font-face {
 					font-family: "Liberation Sans Narrow";


### PR DESCRIPTION
*Not to be merged for now*

The architecture diagrams produced by ivoatex give all boxes the same
width.  That yields a nicely regular appearance but wastes a lot of
space.  And arch diag real estate begins to run short.

Now, I've not found a way to just draw a box around some text in plain
svg.  To see if this is something we'd even want, I've created a JS
simulation of what I'd like to have.

Discussion on this preferably on the IVOA stdproc mailing list; see http://mail.ivoa.net/pipermail/stdproc/2021-January/000110.html