### PR TITLE
Http refs

### DIFF
--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -316,7 +316,12 @@ Dave Winer
   url =          {http://www.w3.org/TR/1999/REC-html401-19991224/}
 }
 
+DO NOT USE std:HTTP in new documents any more.  It has been obsoleted
+by various other RFCs, including std:RFC7230, std:RFC7231, and std:RFC7235,
+which are available below.
+
 @Misc{std:HTTP,
+	obsolete = True,
   author =       {R. Fielding and J. Gettys and J. Mogul and H. Frystyk and L. Masinter and P. Leach and T. Berners-Lee},
   title =        {Hypertext Transfer Protocol -- {HTTP}/1.1},
   howpublished = {{rfc2616}},
@@ -324,6 +329,34 @@ Dave Winer
   year =         1999,
   url =          {http://www.w3.org/Protocols/rfc2616/rfc2616.html}
 }
+
+@misc{std:RFC7231
+  author =       {R. Fielding and J. Reschke},
+  title =        {Hypertext Transfer Protocol ({HTTP}/1.1): Message Syntax and Routing},
+  howpublished = {{RFC 7230}},
+  month =        jun,
+  year =         2014,
+  url =          {https://tools.ietf.org/html/rfc7230}
+}
+
+@misc{std:RFC7231
+  author =       {R. Fielding and J. Reschke},
+  title =        {Hypertext Transfer Protocol ({HTTP}/1.1): Semantics and Content},
+  howpublished = {{RFC 7231}},
+  month =        jun,
+  year =         2014,
+  url =          {https://tools.ietf.org/html/rfc7231}
+}
+
+@misc{std:RFC7235
+  author =       {R. Fielding and J. Reschke},
+  title =        {Hypertext Transfer Protocol ({HTTP}/1.1): Authentication},
+  howpublished = {{RFC 7235}},
+  month =        jun,
+  year =         2014,
+  url =          {https://tools.ietf.org/html/rfc7235}
+}
+
 
 @Misc{std:DNS,
   author =       {P. Mockapetris},

--- a/make-archdiag.xslt
+++ b/make-archdiag.xslt
@@ -85,6 +85,33 @@ want.
 	<svg  version="2.0"
 		width="800" height="600">
 		<defs>
+			<script type="text/javascript">
+			function adjustBoxWidthsForClass(cls) {
+				var recs = document.getElementsByClassName(cls);
+				for (var index in recs) {
+					if (!recs[index].nextSibling || !recs[index].nextSibling.getBBox) {
+						// for some reason we have a 'rec' box not followed by text;
+						// let's skip this for now an see if this bites someone.
+						continue;
+					}
+					var bbox = recs[index].nextSibling.getBBox();
+					var newWidth = bbox.width+6;
+					recs[index].width.baseVal.value = newWidth;
+					recs[index].x.baseVal.value += (90-newWidth)/2;
+				}
+			}
+
+			function adjustBoxWidths() {
+				// Regrettably, SVG doesn't seem to have a facility to bboxes
+				// around text.  We fake this here using javascript, to be
+				// called when the text is rendered.
+				adjustBoxWidthsForClass('rec');
+				adjustBoxWidthsForClass('prerec');
+			}
+
+			window.addEventListener("load", adjustBoxWidths, false);
+			</script>
+
 			<style type="text/css">
 				@font-face {
 					font-family: "Liberation Sans Narrow";


### PR DESCRIPTION
RFC 2616 (http) has been obsoleted for a while by a set of new RFCs.

This PR reflects these changes, though it leaves out the (from a VO perspective) more obscure RFCs on conditional requests, ranges, and caching in the interest of keeping ivoabib short-ish – I don't think too many of our standards will want to reference them.