### PR TITLE
Telling make to delete targets of failed builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 
 IVOATEX_VERSION = 1.1
 
+.DELETE_ON_ERROR:
+
 CSS_HREF = http://www.ivoa.net/misc/ivoa_doc.css
 TTH = ivoatex/tth_C/tth
 ARCHIVE_FILES = $(DOCNAME).tex $(DOCNAME).pdf $(DOCNAME).html $(FIGURES)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IVOATEX_VERSION = 1.1
 
 .DELETE_ON_ERROR:
 
-CSS_HREF = http://www.ivoa.net/misc/ivoa_doc.css
+CSS_HREF = https://www.ivoa.net/misc/ivoa_doc.css
 TTH = ivoatex/tth_C/tth
 ARCHIVE_FILES = $(DOCNAME).tex $(DOCNAME).pdf $(DOCNAME).html $(FIGURES)
 PYTHON?=python3


### PR DESCRIPTION
.DELETE_ON_ERROR might be a GNU extension (I've not researched), but even if there's ever some other make processing this, it at least shouldn't hurt.

Quoting GNU make's info pages:

> This is almost always what you want 'make' to do, but it is not historical practice; so for compatibility, you must explicitly request it.

While I'm at changing the makefile, I'm also changing the CSS href for the HTML rendering to https.  That shouldn't be necessary when ivoa.net properly gives sets up a content-security-policy, and clearly it would save a bit if effort when coming from somewhere else, but overall it's probably less hassle this way.