### PR TITLE
Move to https links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ The design goals are:
 * low to moderate installation effort (on POSIX systems with LaTeX),
 * support with routine drudgery.
 
-.. _IVOA: http://www.ivoa.net
+.. _IVOA: https://www.ivoa.net
 
 
 Getting ivoaTeX
@@ -114,7 +114,7 @@ Documentation
 Documentation on ivoatex, including a chapter on a quick start, is
 given in the IVOA note `The IVOATeX Document Preparation System`_.
 
-.. _The IVOATeX Document Preparation System: http://ivoa.net/documents/Notes/IVOATex/index.html
+.. _The IVOATeX Document Preparation System: https://ivoa.net/documents/Notes/IVOATex/
 
 
 Extra Points for git operation

--- a/document.template
+++ b/document.template
@@ -34,7 +34,7 @@ interpreted as described in IETF standard RFC2119 \citep{std:RFC2119}.
 The \emph{Virtual Observatory (VO)} is a
 general term for a collection of federated resources that can be used
 to conduct astronomical research, education, and outreach.
-The \href{http://www.ivoa.net}{International
+The \href{https://www.ivoa.net}{International
 Virtual Observatory Alliance (IVOA)} is a global
 collaboration of separately funded projects to develop standards and
 infrastructure that enable VO applications.

--- a/ivoa.cls
+++ b/ivoa.cls
@@ -261,18 +261,18 @@
      interoperability inside the Astronomical Community.}
 		{UNKNOWN DOCUMENT (fix DOCTYPE)}}}}}}\par
 	A list of current IVOA Recommendations and other technical documents
-	can be found at \href{http://www.ivoa.net/documents/
-	}{http://www.ivoa.net/documents/}.}
+	can be found at \href{https://www.ivoa.net/documents/
+	}{https://www.ivoa.net/documents/}.}
 
 
 \newcommand\currentBaseURL % 
-	{http://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode}
+	{https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode}
 \newcommand\currentDocURL % URL of this document's landing page
 	{\href{\currentBaseURL}{\currentBaseURL}}
 \newcommand\latestDocURL 
 	% URL of a potential successor to the document's landing page
-	{\href{http://www.ivoa.net/documents/\ivoaDocname}
-		{http://www.ivoa.net/documents/\ivoaDocname}}
+	{\href{https://www.ivoa.net/documents/\ivoaDocname}
+		{https://www.ivoa.net/documents/\ivoaDocname}}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Styling various item

--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -688,7 +688,7 @@ archivePrefix = "arXiv",
 
 @INPROCEEDINGS{2005ASPC..347...29T,
    author = {{Taylor}, M.~B.},
-    title = "{TOPCAT {\amp} STIL: Starlink Table/VOTable Processing Software}",
+    title = "{TOPCAT {\&} STIL: Starlink Table/VOTable Processing Software}",
 booktitle = {Astronomical Data Analysis Software and Systems XIV},
      year = 2005,
    series = {Astronomical Society of the Pacific Conference Series},

--- a/schemadoc.xslt
+++ b/schemadoc.xslt
@@ -303,18 +303,14 @@ Copyright 2015, The GAVO project
   <xsl:template match="@type[.='vr:ResourceName']" priority="1" mode="type">
     <xsl:text>string with ID attribute: </xsl:text>
     <code>
-      <a href="http://www.ivoa.net/Documents/REC/ReR/VOResource-20080222.html#d:ResourceName">
         <xsl:text>vr:ResourceName</xsl:text>
-      </a>
     </code>
   </xsl:template>
 
   <xsl:template match="@type[.='vr:IdentifierURI']" priority="1" mode="type">
     <xsl:text>an IVOA Identifier URI: </xsl:text>
     <code>
-      <a href="http://www.ivoa.net/Documents/REC/ReR/VOResource-20080222.html#d:IdentifierURI">
         <xsl:text>vr:IdentifierURI</xsl:text>
-      </a>
     </code>
   </xsl:template>
 

--- a/stdrec-template.xml
+++ b/stdrec-template.xml
@@ -21,11 +21,11 @@ change updated whenever you re-upload this record. -->
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
 	xsi:schemaLocation="http://www.ivoa.net/xml/VOResource/v1.0
-		http://www.ivoa.net/xml/VOResource/v1.0
+		https://www.ivoa.net/xml/VOResource/v1.0
 	http://www.ivoa.net/xml/StandardsRegExt/v1.0
-		http://www.ivoa.net/xml/StandardsRegExt/v1.0
+		https://www.ivoa.net/xml/StandardsRegExt/v1.0
 	http://www.ivoa.net/xml/VOResource/v1.0
-		http://www.ivoa.net/xml/VOResource/v1.0">
+		https://www.ivoa.net/xml/VOResource/v1.0">
 
   <title>####</title> <!-- title as given on the standard's title page -->
   <shortName>####</shortName> <!-- this should be your DOCNAME -->
@@ -58,7 +58,7 @@ change updated whenever you re-upload this record. -->
     <!-- you can give further keywords, one per subject element;
     use the Unified Astronomy Thesaurus if possible:
 
-    http://www.ivoa.net/rdf/uat
+    https://www.ivoa.net/rdf/uat
     -->
     <subject>####</subject>
 
@@ -66,7 +66,7 @@ change updated whenever you re-upload this record. -->
     	#### (your abstract; no markup here, please)
     </description>
     <referenceURL>#### (the generic landing page URL, e.g.
-    	http://ivoa.net/documents/SAMP/)</referenceURL>
+    	https://ivoa.net/documents/SAMP/)</referenceURL>
     <type>Other</type>
   	<contentLevel>Research</contentLevel>
   </content>
@@ -86,7 +86,7 @@ change updated whenever you re-upload this record. -->
 	<!-- You can furthermore have as many key-value pairs as you want.
 		Service standard authors will need this to comply with Identifier 2.0's
 		recommendation for standardId 
-		(http://www.ivoa.net/documents/IVOAIdentifiers/20150709/PR-Identifiers-2.0-20150709.html#tth_sEc4.2) -->
+		(https://www.ivoa.net/documents/IVOAIdentifiers/20150709/PR-Identifiers-2.0-20150709.html#tth_sEc4.2) -->
 	<key>
 		<name>####</name>
 		<description>####

--- a/svn-ignore.txt
+++ b/svn-ignore.txt
@@ -10,3 +10,4 @@ ivoatexmeta.tex
 *.zip
 *.fdb_latexmk
 *.fls
+gitmeta.tex

--- a/tth-ivoa.xslt
+++ b/tth-ivoa.xslt
@@ -490,7 +490,9 @@
   </xsl:template>
 
   <xsl:template match="body">
-    <xsl:apply-templates/>
+  	<body>
+	    <xsl:apply-templates/>
+	  </body>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/tth-ivoa.xslt
+++ b/tth-ivoa.xslt
@@ -8,7 +8,7 @@
        in final versions, but draft versions may appear for a while at
        a different location, and this can be parameterised when this
        stylesheet is invoked. -->
-  <xsl:param name='docbase'>http://www.ivoa.net/documents/</xsl:param>
+  <xsl:param name='docbase'>https://www.ivoa.net/documents/</xsl:param>
 
   <xsl:param name="CSS_HREF" select="''"/>
 
@@ -177,7 +177,7 @@
     <xsl:copy>
       <table cellspacing="0" cellpadding="0" width="450">
       <tr>
-        <td><a href="http://www.ivoa.net/"><img height="169" alt="IVOA" src="http://www.ivoa.net/icons/IVOA_wb_300.jpg" width="300" border="0"/></a></td>
+        <td><a href="https://www.ivoa.net/"><img height="169" alt="IVOA" src="https://www.ivoa.net/icons/IVOA_wb_300.jpg" width="300" border="0"/></a></td>
         <td>
         <div style="padding: 3.6pt 7.2pt;">
         <p><b><i><span style="font-size: 14pt; color: rgb(0, 90, 156);"><span>&#xa0;</span>I</span></i></b><i><span style="font-size: 14pt; color: rgb(0, 90, 156);">nternational</span></i></p>
@@ -366,7 +366,7 @@
       </em></p>
 
       <p>A list of current IVOA Recommendations and other technical documents
-        can be found in the <a href="http://www.ivoa.net/documents">IVOA
+        can be found in the <a href="https://www.ivoa.net/documents">IVOA
         document repository</a>.</p>
   </xsl:template>
 
@@ -376,17 +376,17 @@
       <xsl:attribute name="href">
         <xsl:choose>
          <xsl:when test="$doctype='WD'"
-            >http://www.ivoa.net/misc/ivoa_wd.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_wd.css</xsl:when>
          <xsl:when test="$doctype='PR'"
-            >http://www.ivoa.net/misc/ivoa_pr.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_pr.css</xsl:when>
          <xsl:when test="$doctype='REC'"
-            >http://www.ivoa.net/misc/ivoa_rec.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_rec.css</xsl:when>
          <xsl:when test="$doctype='NOTE'"
-            >http://www.ivoa.net/misc/ivoa_note.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_note.css</xsl:when>
          <xsl:when test="$doctype='PEN'"
-            >http://www.ivoa.net/misc/ivoa_pen.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_pen.css</xsl:when>
          <xsl:when test="$doctype='EN'"
-            >http://www.ivoa.net/misc/ivoa_en.css</xsl:when>
+            >https://www.ivoa.net/misc/ivoa_en.css</xsl:when>
        </xsl:choose>
      </xsl:attribute>
      </link>

--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -131,8 +131,8 @@
   \special{html:<span class="ivoatex">IVOAT<sub>E</sub>X</span>}}
 
 \newcommand{\auxiliaryurl}[1]{%
-  \href{http://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1}
-  {http://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1}}
+  \href{https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1}
+  {https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1}}
 
 \newenvironment{inlinetable}{}{}
 


### PR DESCRIPTION
This PR moves quite a few links into the IVOA web page to https.
While in principle, people are redirected, setting the links properly
saves one redirect.  In the case of the CSS references, having
them point to https directly saves us from having to rely on
upgrade-insecure-requests for having CSS when the documents are
requested via https.

I'm sneaking in to really minor-impact unrelated commits: for one, ivoatex-produced html so far has been missing body tags, and the svn-ignore.txt template now also ignores gitmeta.tex, which is going to help a lot.  I'd hate to have to write dedicated PRs for these two little things.