### PR TITLE
[CI] Update the template for the GitHub Workflow "PDF Preview".

### DIFF
--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -41,10 +41,10 @@ jobs:
         test -f ${{ env.doc_name }}.bbl
     
     - name: Move the auto-pdf-preview tag
-      uses: weareyipyip/walking-tag-action@v1
+      uses: weareyipyip/walking-tag-action@v2
       with:
-        TAG_NAME: auto-pdf-preview
-        TAG_MESSAGE: |
+        tag-name: auto-pdf-preview
+        tag-message: |
           Last commit taken into account for the automatically updated PDF preview of this IVOA document.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the tag name and message for the GitHub Action
[Walking Tag](https://github.com/marketplace/actions/walking-git-tag)
accordingly to its last version. This make disappear the warning message about
the former `TAG_NAME` and `TAG_MESSAGE`.

_See the Walking-Tag's [commit 5242039](weareyipyip/walking-tag-action@5242039)
for more details about this change._