### PR TITLE
Adding a ucd macro.

### DIFF
--- a/ivoa.cls
+++ b/ivoa.cls
@@ -338,6 +338,18 @@
 
 \newcommand{\xmlel}[1]{{\ttfamily\itshape #1}}
 \newcommand{\vorent}[1]{\textsc{#1}}
+\def\ucd{\st@rtucd\re@lucd}
+\def\re@lucd#1{\sl#1\@nducd}
+\begingroup
+% let LaTeX break UCD componds and at dots and semicolons in UCDs
+\gdef\bre@kabledot{.\hskip0pt}
+\gdef\bre@kablesemicolon{;\hskip0pt}
+\catcode`\.=\active\catcode`\;=\active
+\gdef\st@rtucd{\begingroup
+  \catcode`\.=\active\let.=\bre@kabledot
+  \catcode`\;=\active\let;=\bre@kablesemicolon}
+\gdef\@nducd{\endgroup}
+\endgroup
 
 \newcommand{\sptablerule}{\noalign{\vspace{2pt}}\hline\noalign{\vspace{2pt}}}
 

--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -116,6 +116,7 @@
   \begin{html}<span class="#1">\end{html}#2\begin{html}</span>\end{html}}
 \newcommand{\xmlel}[1]{\specialterm{xmlel}{#1}}
 \newcommand{\vorent}[1]{\specialterm{vorent}{#1}}
+\newcommand{\ucd}[1]{{\sl #1}}
 
 %don't do table rules, these come in through CSS
 \newcommand{\sptablerule}{}


### PR DESCRIPTION
Apart from a bit of uniform markup, this in particular enables breaking
UCDs at semicolons and dots.  As a side effect, atoms can be hyphenated,
too.

If this is merged, the corresponding definitions in EPN-TAP should be
removed; UCDList's ucd macro is different (at least for now) and probably
should stay that way because of the special requirements in UCD presentation
there.