### PR TITLE
Amending make clean target for latexmk (and ignoring vi swap files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tth_C/tth
+.*.swp

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ arxiv-upload: $(SOURCES) biblio $(FIGURES) $(VECTORFIGURES) ivoatexmeta.tex
 clean:
 	rm -f $(DOCNAME).pdf $(DOCNAME).aux $(DOCNAME).log $(DOCNAME).toc texput.log ivoatexmeta.tex
 	rm -f $(DOCNAME).html $(DOCNAME).xhtml
-	rm -f *.bbl *.blg *.out debug.html
+	rm -f *.bbl *.blg *.out debug.html *.fls *.fdb_latexmk
 	rm -f arxiv-upload.tar.gz
 	rm -f $(GENERATED_PNGS)
 


### PR DESCRIPTION
I'm sneaking in a .gitignore amendment for ignoring vi swap files, too.