### PR TITLE
Now ignoring role-diagram.svg by default

### DIFF
--- a/svn-ignore.txt
+++ b/svn-ignore.txt
@@ -11,3 +11,5 @@ ivoatexmeta.tex
 *.fdb_latexmk
 *.fls
 gitmeta.tex
+*.swp
+role_diagram.svg


### PR DESCRIPTION
This is because it's really cheap to remake (nothing will work without
xsltproc anyway).

Using the opportunity to also ignore gvim swap files.