### PR TITLE
Ignore Mac .DS_Store files

### DIFF
--- a/svn-ignore.txt
+++ b/svn-ignore.txt
@@ -13,3 +13,6 @@ ivoatexmeta.tex
 gitmeta.tex
 *.swp
 role_diagram.svg
+
+# OS-specific
+.DS_Store


### PR DESCRIPTION
As a minor convenience, ignore the `.DS_Store` files that Macs sometimes put in directories when they've been browsed with the `Finder` application.

Side question:  While in `svn-ignore.txt`, I noticed `role_diagram.svg` and `*.pdf`.  Those seem in conflict with the current guidance of including `role_diagram.svg` and `role_diagram.pdf` in the repository as a work-around to the `inkscape` build dependency.  Depending on how long that guidance will be in place, would it make sense to replace the `role_diagram.svg` line (allow that file) with `!role_diagram.pdf` (explicitly allow that pdf while still ignoring all others)?