### PR TITLE
Add bibupgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tth_C/tth
 .*.swp
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,10 @@ role_diagram.svg: role_diagram.xml
 # Also, it needs python installed, which may not be available on all
 # installations.
 generate:
-	$(PYTHON) ivoatex/update_generated.py $(DOCNAME).tex
+	$(PYTHON) ivoatex/update_generated.py "$(DOCNAME).tex"
+
+bib-suggestions: $(DOCNAME).pdf
+	$(PYTHON) ivoatex/suggest-bibupgrade.py $(DOCNAME).aux
 
 package: $(DOCNAME).tex $(DOCNAME).html $(DOCNAME).pdf \
 		$(GENERATED_PNGS)	$(FIGURES) $(AUX_FILES)

--- a/README.rst
+++ b/README.rst
@@ -25,15 +25,11 @@ preferably via mechanisms of the version control system chosen (e.g.,
 IvoaTeX is currently maintained in two places:
 
 * https://volute.g-vo.org/svn/trunk/projects/ivoapub/ivoatex – this is the 
-  original site on volute (an IVOA-affiliated subversion repository).
-* https://github.com/ivoa-std/ivoatex.git – this is experimental and git-based; it
-  is likely that ivoaTeX's recommended process will move to using this at some
-  point.
-
-Because of this situation, some of the points below are mentioned twice, once
-for github and once for volute.
-
-The two locations are being kept in sync manually.
+  legacy site on volute (an IVOA-affiliated subversion repository).  It
+  is being phased out.
+* https://github.com/ivoa-std/ivoatex.git – this is where development
+  happens and what should be used as the submodule in new IVOA
+  standards.
 
 
 Crib Sheet
@@ -49,31 +45,17 @@ Installing the dependencies
 Debian-derived systems::
 
   apt-get install build-essential texlive-latex-extra zip xsltproc\
-    texlive-bibtex-extra imagemagick ghostscript cm-super librsvg2-bin
+    texlive-bibtex-extra latexmk librsvg2-bin ghostscript cm-super\
+    librsvg2-bin
 
 Fedora::
 
   dnf install texlive-scheme-full libxslt make gcc zip\
-    ImageMagick ghostscript
+    librsvg2-tools ImageMagick ghostscript
 
 Mac OS X with MacPorts::
 
   port install ImageMagick  libxslt ghostscript texlive +full
-
-
-Checking Out and Building a Document from Volute
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Where documents are still developed on the Volute VCS, use something like the
-following to build a document; in the example, the ivoatex documentation
-is built::
-
-	svn co https://volute.g-vo.org/svn/trunk/projects/ivoapub/ivoatexDoc
-	cd ivoatexDoc
-	make biblio
-	make forcetex
-
-Then start your favourite PDF viewer on ivoatexDoc.pdf.
 
 
 Checking Out a Standard from Github and Building it
@@ -86,7 +68,8 @@ Documents developed on github can be built like this::
    make biblio
    make forcetex
 
-This produces the standards document ``ADQL.pdf``.
+This produces the standards document ``ADQL.pdf``.  If you have latexmk
+installed, a simple ``make`` will work as well.
 
 Automatic PDF preview in GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,19 +98,6 @@ Documentation on ivoatex, including a chapter on a quick start, is
 given in the IVOA note `The IVOATeX Document Preparation System`_.
 
 .. _The IVOATeX Document Preparation System: https://ivoa.net/documents/Notes/IVOATex/
-
-
-Extra Points for git operation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-(This is a temporary accumulator for git-related stuff that should go
-into ivoatexDoc once it's stabilised)
-
-(1) VCS info in the documents: ivoatex 1.2, sect 3.8 is svn-specific.  To have
-info on the git commit in the document heading, instead do:
-
-* Add gitmeta.tex to SOURCES in the Makefile
-* Say ``\input gitmeta`` right below ``\input tthdefs`` in your document.
 
 
 Trouble?
@@ -169,7 +139,7 @@ What is inserted into the CSS within the XSLT is then the output of::
 License
 -------
 
-Unless stated otherwise in the files, ivoatex is (c) 2014-2019, the
+Unless stated otherwise in the files, ivoatex is (c) 2014-2022, the
 GAVO project and can be used and distributed under the GNU General
 Public License (ask for additional licenses if you're unhappy with the
 GPL). See COPYING for details.

--- a/suggest-bibupgrade.py
+++ b/suggest-bibupgrade.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3
+"""
+A script somewhat naively looking for outdated references an suggesting 
+updates.
+
+This expects the name of an .aux file as produced by a LaTeX run.  I'd
+expect this to be run through 
+
+make bib-suggestions 
+
+exclusively.
+
+If this actually gets use, we might think about flagging false positives
+(i.e., cases where document references are really version-sharp.
+
+Maintenance: Occasionally look at the diffs on docrepo.bib; anything that's 
+not version 1 very likely belongs here.
+"""
+
+import re
+import sys
+
+# Maintain docmap as (new) (old) with any whitespace and one pair per line
+# Yes, that's the NEW reference tag first.  It's what you see first when
+# inspecting things.
+_DOCMAP ="""
+2010ivoa.spec.1202P 2021ivoa.spec.1102D 
+2021ivoa.spec.1101D 2010ivoa.rept.1123A 
+2021ivoa.spec.0616C 2018ivoa.spec.0527P 
+2021ivoa.spec.0525D 2009ivoa.spec.1007G 
+2019ivoa.spec.1021O 2013ivoa.spec.0920O 
+2019ivoa.spec.1011D 2014ivoa.spec.1208D 
+2019ivoa.spec.1007G 2006ivoa.spec.0528P 
+2019ivoa.spec.1007F 2014ivoa.spec.0602F 
+2019ivoa.spec.0927D 2011ivoa.spec.1028T 
+2018ivoa.spec.0723D 2009ivoa.spec.1104B 
+2018ivoa.spec.0625P 2008ivoa.spec.0222P 
+2018ivoa.spec.0621G 2013ivoa.spec.0329G 
+2018ivoa.spec.0527P 2007ivoa.spec.0402P
+2017ivoa.spec.0530P 2013ivoa.spec.1125P
+2017ivoa.spec.0524T 2008ivoa.spec.0124R
+2017ivoa.spec.0524G 2011ivoa.spec.0531G
+2017ivoa.spec.0517G 2010ivoa.spec.0413H
+2017ivoa.spec.0517D 2013ivoa.spec.1129D
+2017ivoa.spec.0509L 2011ivoa.spec.1028T
+2016ivoa.spec.1024H 2010ivoa.spec.1010H
+2016ivoa.spec.0523D 2007ivoa.spec.0314P
+2015ivoa.spec.1223D 2009ivoa.spec.1111H
+2013ivoa.spec.0920O 2009ivoa.spec.1130O
+2013ivoa.spec.0329G 2009ivoa.specQ1007G
+2012ivoa.spec.1104T 2012ivoa.spec.0411B
+2012ivoa.spec.0210T 2008ivoa.spec.0201D
+2008ivoa.spec.0201D 2007ivoa.spec.1220D
+2011ivoa.spec.0711S 2006ivoa.spec.1101S
+2010ivoa.spec.1216B 2009ivoa.spec.0421B
+2010ivoa.spec.0413H 2003ivoa.spec.1024H
+2009ivoa.spec.1130O 2004ivoa.spec.0811O
+2009ivoa.specQ1007G 2008ivoa.spec.0124G
+2008ivoa.spec.0325L 2007ivoa.spec.1108L
+2008ivoa.spec.0201D 2007ivoa.spec.1220D
+2007ivoa.spec.0402P 2005ivoa.spec.1231D
+2007ivoa.spec.0302H 2004ivoa.spec.0426H
+2007ivoa.spec.0302H std:RM
+2017ivoa.spec.0517G std:DocSTDProc
+2017ivoa.spec.0517G std:DocSTD
+2016ivoa.spec.0523D std:VOID
+2016ivoa.spec.0523D std:VOID2
+2018ivoa.spec.0625P std:VOR
+2016ivoa.spec.1024H std:UWS
+2016ivoa.spec.1024H std:UWS11
+2019ivoa.spec.0927D std:TAP
+2017ivoa.spec.0530P std:DALREGEXT
+2010ivoa.spec.1202P std:VODS11
+2017ivoa.spec.0517D std:DALI
+2017ivoa.spec.0517D std:DALI11
+2011ivoa.spec.0711S std:VOEVENT
+2011ivoa.spec.0711S std:VOEVENT2
+2005ivoa.spec.0819D std:UCD
+2012ivoa.spec.0508H std:STDREGEXT
+2012ivoa.spec.0827D std:TAPREGEXT
+2015ivoa.spec.1223D std:SIAv2
+2015ivoa.spec.1223D std:SIAP
+2008ivoa.specQ0222P std:SCS
+2012ivoa.spec.0210T std:SSAP
+2008ivoa.spec.1030O std:ADQL
+2018ivoa.spec.0621G std:VOSPACE
+2018ivoa.spec.0723D std:RI1
+2019ivoa.spec.1011D std:RI2
+2007ivoa.spec.1030R std:STC
+2017ivoa.spec.0524T std:SSOAUTH
+2017ivoa.spec.0524T std:SSOAUTH2
+2010ivoa.spec.0218P std:CDP
+2017ivoa.spec.0524G std:VOSI
+2017ivoa.spec.0524G std:VOSI11
+2014ivoa.spec.0523D std:VOUNIT
+2017ivoa.spec.0509L std:OBSCORE
+2011ivoa.spec.1120M std:SDM
+2019ivoa.spec.1007F std:MOC
+2019ivoa.spec.1011D std:RegTAP
+2015ivoa.spec.0617D std:DataLink
+2019ivoa.spec.1021O std:VOTABLE
+2021ivoa.spec.1101D note:VOARCH
+2018ivoa.spec.0529H note:schemaversioning
+2019ivoa.spec.0520D note:DataCollect
+2013ivoa.rept.1213D note:TAPNotes
+2010ivoa.rept.0618D note:votstc
+"""
+
+
+OLD2NEW = dict((p[1], p[0]) 
+    for p in (ln.split()
+        for ln in _DOCMAP.split("\n") if ln.strip()))
+
+
+def get_suggestion(ref_tag):
+    """returns a suggestion for what to replace ref_tag with.
+
+    If ref_tag seems up to date, it is returned unchanged.
+    """
+    while ref_tag in OLD2NEW:
+        ref_tag = OLD2NEW[ref_tag]
+    return ref_tag
+
+
+def iter_ref_tags(f):
+    """yields all arguments of citation macro calls within the file f's 
+    content.
+
+    We expect the citation calls to be all in one line and without 
+    whitespace and all that.  I think that's how LaTeX produces them:
+    We're reading from an aux file here.
+    """
+    pat = re.compile(r"\\citation\{([^}]*)}")
+    for ln in f:
+        mat = pat.search(ln)
+        if mat:
+            yield mat.group(1)
+
+def main():
+    if len(sys.argv)!=2:
+        sys.exit("Do not call this script directly.")
+
+    with open(sys.argv[1], encoding="utf-8") as f:
+        for ref_tag in iter_ref_tags(f):
+            replacement = get_suggestion(ref_tag)
+            if replacement!=ref_tag:
+                print(f"{ref_tag} -> {replacement} ?")
+
+
+class TestSuggestions:
+    def test_unknown(self):
+        assert get_suggestion("whatever")=="whatever"
+
+    def test_recursive(self):
+        assert get_suggestion("2004ivoa.spec.0811O")=="2019ivoa.spec.1021O"
+
+
+def test_get_suggestion():
+    import io
+    input = io.StringIO(
+        "Something not involving citation{ or something\n"
+        "\\citation{one}\n"
+        "A maformed \\citation{ought to be ignored\n"
+        "\\citation{two} and junk after, too.\n")
+    assert list(iter_ref_tags(input))==["one", "two"]
+
+
+if __name__=="__main__":
+    main()

--- a/suggest-bibupgrade.py
+++ b/suggest-bibupgrade.py
@@ -136,15 +136,27 @@ def iter_ref_tags(f):
         if mat:
             yield mat.group(1)
 
+
 def main():
     if len(sys.argv)!=2:
         sys.exit("Do not call this script directly.")
 
+    suggestions = {}
     with open(sys.argv[1], encoding="utf-8") as f:
         for ref_tag in iter_ref_tags(f):
             replacement = get_suggestion(ref_tag)
             if replacement!=ref_tag:
-                print(f"{ref_tag} -> {replacement} ?")
+                suggestions[ref_tag] = replacement
+
+    if suggestions:
+        # There may be a bit of mess from the LaTeX run(s) above us, so feed
+        # a bit of white space.
+        print("\n\n*** Consider updating the following references:")
+        for ref_tag, replacement in suggestions.items():
+            print(f"{ref_tag} -> {replacement} ?")
+    
+    else:
+        print("\n\n*** All references seem up to date.")
 
 
 class TestSuggestions:


### PR DESCRIPTION
The idea of this change is that people can, when re-uptaking a document
or before submission, say

make bib-suggestions

and the machine will tell them for which documents there are newer versions.  This is based on a hand-curated list; one day in the future we may be able to automate its generation, but for now it's probably not much effort to maintain that mapping.

Automatic fixes of the citations are quite certainly too dangerous, as we may have version-sharp references.

The stuff may be a bit more helpful if it wouldn't just put in the bibcodes; but since that would entail searching and formatting bibtex records, I'd first like to see folks clamour for that.