### PR TITLE
Requiring textcomp, too.

### DIFF
--- a/ivoa.cls
+++ b/ivoa.cls
@@ -9,6 +9,7 @@
 \RequirePackage{ifthen}
 \RequirePackage{doc}
 \RequirePackage{listings}
+\RequirePackage{textcomp}
 \RequirePackage{paralist}
 \RequirePackage{url}
 \RequirePackage[nottoc]{tocbibind}


### PR DESCRIPTION
This is required for the upquote option to lstlistings on older
installations.