### PR TITLE
make update will now rebase ivoatex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean:
 
 update:
 	@echo "*** updating ivoatex from github"
-	git submodule update --remote
+	git submodule update --remote --rebase
 
 .FORCE:
 


### PR DESCRIPTION
That's necessary to keep ivoatex from getting stuck at the original commit.
Oh my -- talk about a somewhat odd default.