### PR TITLE
Updating tth to upstream 4.16.

### DIFF
--- a/tth_C/CHANGES
+++ b/tth_C/CHANGES
@@ -1,3 +1,20 @@
+Version 4.15 (19 Sep 2020)
+____________
+Make svg a recognized graphic file for direct embedding.
+Implement \nolinkurl
+Fix double apersand escaping in url handling.
+
+Version 4.14 (17 Jul 2020)
+____________
+Fix tth_stack_ptr miscount in footnote code
+Fix incorrect \index{} anchor in non-book usage
+Silence recent officious GCC string warnings in makefile
+
+Version 4.13
+____________
+Fix \caption within newenvironment bug, but nested environments will
+generally break the automatic numbering.
+
 Version 4.12
 ____________
 Give Mathml eqalign equations the <table displaystyle="true"> attribute.

--- a/tth_C/CHANGES
+++ b/tth_C/CHANGES
@@ -1,8 +1,12 @@
+Version 4.16 (25 July 2022)
+____________
+Render | as | in \textt{} rather than ---
+
 Version 4.15 (19 Sep 2020)
 ____________
 Make svg a recognized graphic file for direct embedding.
 Implement \nolinkurl
-Fix double apersand escaping in url handling.
+Fix double ampersand escaping in url handling.
 
 Version 4.14 (17 Jul 2020)
 ____________

--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -1,8 +1,8 @@
 /* TtH TeX to HTML translator.
 TtH Version 
-"4.13"
+"4.15"
  (c) Ian Hutchinson
-Sun Dec 17 17:43:50 EST 2017
+Sat Sep 19 13:55:17 EDT 2020
 */
 
 #line 3 "lex.yy.c"
@@ -14307,17 +14307,17 @@ int yy_flex_debug = 0;
 char *yytext;
 #line 1 "tth.lex"
 /* TtH flex file to convert plain TeX and LaTeX to HTML.
-(c) Ian Hutchinson, 1997-2011.
+(c) Ian Hutchinson, 1997-2020.
 Released under the terms of the GPL2. See license.txt
 This file needs to be turned into a C program using flex
 And then compiled into the tth executable using a C compiler.
 */
 #line 10 "tth.lex"
-#define TTH_VERSION "4.12"
+#define TTH_VERSION "4.15"
   /*#define TTH_GOLD "gold" no longer a distinction*/  /*sf*/
 #define TTH_HEAD "HEAD"  /*sf*/
 char tth_DOC[]="\n\
-                Version XXXX (c)1997-2017 Ian Hutchinson\n\
+                Version XXXX (c)1997-2020 Ian Hutchinson\n\
             TtH (TeX-to-HTML) translates TeX into HTML.\n\n\
 The program is a filter by default: it reads from stdin and writes to stdout.\n\
 But a non-switch argument specifies the file[.tex] to translate to file.html.\n\
@@ -14615,7 +14615,8 @@ char *tth_builtins = "\\def\\bye{\\vfill\\eject\\end }\
 \\def\\bm#1{{\\tth_bm #1}}\
 \\newenvironment{abstract}{\\begin{tthabstract}}{\\end{tthabstract}}\
 \\newcommand\\tthoutopt[1][]{#1}\n\
-\\newcommand\\tthnooutopt[1][]{}\n";
+\\newcommand\\tthnooutopt[1][]{}\n\
+\\def\\nolinkurl#!{\\verb!#1!}";
 
  /* static functions */
 static int indexkey();
@@ -14817,7 +14818,7 @@ as dugroup. */
 /* NOA	[^a-zA-Z0-9] Removed 1.04 */
 /* Old versions. WSP     [ \t\n] WSC     [^ \t\n] NL      \n */
 /* Costs 120k C! BRCG   \{[^\}]*(\{[^\}]*(\{[^\}]*\})?[^\}]*\})?[^\}]*\} */
-#line 14815 "lex.yy.c"
+#line 14816 "lex.yy.c"
 
 #define INITIAL 0
 #define pargroup 1
@@ -15103,7 +15104,7 @@ YY_DECL
 	register char *yy_cp, *yy_bp;
 	register int yy_act;
     
-#line 540 "tth.lex"
+#line 541 "tth.lex"
 
 
   /* Local storage */
@@ -15137,6 +15138,7 @@ STATIC char boxalign[TTH_CHARLEN]={0};
 STATIC char boxvalign[TTH_CHARLEN]={0};
 STATIC char dupstore[TTH_DLEN];
 STATIC char dupstore2[2*TTH_DLEN];
+STATIC char dupstore3[2*TTH_DLEN];
 STATIC char supstore[TTH_DLEN]={0};
 STATIC char substore[TTH_DLEN]={0};
 STATIC char defstore[TTH_DLEN]={0};
@@ -15712,7 +15714,7 @@ tth_flev=tth_flev0;
 
  /******************************* RULES *****************************/
 
-#line 15710 "lex.yy.c"
+#line 15712 "lex.yy.c"
 
 	if ( !(yy_init) )
 		{
@@ -15797,91 +15799,91 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 1148 "tth.lex"
+#line 1150 "tth.lex"
 nbuiltins=nkeys;tth_debug=tth_LaTeX-1;fprintf(tth_fdout,"\n");
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 1149 "tth.lex"
+#line 1151 "tth.lex"
 nbuiltins=nkeys; bibliogs=0;
 	YY_BREAK
 /* Strip out formating commands. */
 case 3:
 YY_RULE_SETUP
-#line 1152 "tth.lex"
+#line 1154 "tth.lex"
 
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 1153 "tth.lex"
+#line 1155 "tth.lex"
 
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 1154 "tth.lex"
+#line 1156 "tth.lex"
 
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 1155 "tth.lex"
+#line 1157 "tth.lex"
 
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 1156 "tth.lex"
+#line 1158 "tth.lex"
 
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 1157 "tth.lex"
+#line 1159 "tth.lex"
 
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 1158 "tth.lex"
+#line 1160 "tth.lex"
 
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 1159 "tth.lex"
+#line 1161 "tth.lex"
 
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 1160 "tth.lex"
+#line 1162 "tth.lex"
 
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 1161 "tth.lex"
+#line 1163 "tth.lex"
 
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 1162 "tth.lex"
+#line 1164 "tth.lex"
 
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 1163 "tth.lex"
+#line 1165 "tth.lex"
 
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 1164 "tth.lex"
+#line 1166 "tth.lex"
 
 	YY_BREAK
 case 16:
-#line 1166 "tth.lex"
+#line 1168 "tth.lex"
 case 17:
 YY_RULE_SETUP
-#line 1166 "tth.lex"
+#line 1168 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 /* external macro expansion in notags.*/
 case 18:
 YY_RULE_SETUP
-#line 1168 "tth.lex"
+#line 1170 "tth.lex"
 {
   if(tth_titlestate&1){
     TTH_DO_MACRO else{TTH_OUTPUT(yytext);}
@@ -15892,12 +15894,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 1175 "tth.lex"
+#line 1177 "tth.lex"
 TTH_OUTPUT(yytext+1);
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 1176 "tth.lex"
+#line 1178 "tth.lex"
 {
   if(tth_titlestate&2){
     tth_tagpurge=1;
@@ -15907,7 +15909,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 1183 "tth.lex"
+#line 1185 "tth.lex"
 {
   if(tth_titlestate){
     yy_push_state(notags);
@@ -15919,7 +15921,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 1191 "tth.lex"
+#line 1193 "tth.lex"
 { /* Defined as a latex command with optional arg */
   verbinput=1;
   TTH_TEX_FN_OPT("\\tth_verbinput #2 \\tth_endverbinput#tthdrop2",2,"");
@@ -15927,7 +15929,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 1195 "tth.lex"
+#line 1197 "tth.lex"
 {
   fprintf(tth_fdout,"\n<pre>"); yy_push_state(verbatim); /*begin verbatim*/
   TTH_PUSH_CLOSING;  TTH_CCPY(closing,"</pre>");
@@ -15936,15 +15938,15 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 24:
-#line 1203 "tth.lex"
+#line 1205 "tth.lex"
 case 25:
 YY_RULE_SETUP
-#line 1203 "tth.lex"
+#line 1205 "tth.lex"
 TTH_TEX_FN("\\tthexpandafter#tthdrop1",1);
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 1204 "tth.lex"
+#line 1206 "tth.lex"
 {
   if(horizmode) horizmode=1;
   js2=indexkey("#1",margkeys,&margmax);
@@ -15957,21 +15959,21 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 27:
-#line 1215 "tth.lex"
+#line 1217 "tth.lex"
 case 28:
 YY_RULE_SETUP
-#line 1215 "tth.lex"
+#line 1217 "tth.lex"
 yy_push_state(csname);strcpy(scratchstring," ");
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 1216 "tth.lex"
+#line 1218 "tth.lex"
 strcat(scratchstring,yytext);
 	YY_BREAK
 case 30:
 /* rule 30 can match eol */
 YY_RULE_SETUP
-#line 1217 "tth.lex"
+#line 1219 "tth.lex"
 {
   fprintf(stderr,"**** Error: line end in csname. Syntax error? Line %d\n",tth_num_lines);
   TTH_SCAN_STRING("\\endcsname");
@@ -15979,7 +15981,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 1221 "tth.lex"
+#line 1223 "tth.lex"
 {
   yy_pop_state();
   chscratch=scratchstring+strspn(scratchstring," \t")-1;
@@ -15992,7 +15994,7 @@ YY_RULE_SETUP
 /* Put any personal rules here unless there is some special reason. */
 case 32:
 YY_RULE_SETUP
-#line 1231 "tth.lex"
+#line 1233 "tth.lex"
 {
   TTH_OUTPUT(TTH_Large);TTH_PRECLOSE(TTH_SIZEEND);
   TTH_OUTPUT(TTH_BOLD1);TTH_PRECLOSE(TTH_BOLD2);
@@ -16001,16 +16003,16 @@ YY_RULE_SETUP
 case 33:
 /* rule 33 can match eol */
 YY_RULE_SETUP
-#line 1235 "tth.lex"
+#line 1237 "tth.lex"
 {
   TTH_INC_MULTI;
   TTH_SCAN_STRING("\\epsfbox");
 }
 	YY_BREAK
 case 34:
-#line 1240 "tth.lex"
+#line 1242 "tth.lex"
 case 35:
-#line 1241 "tth.lex"
+#line 1243 "tth.lex"
 /* \\epsfbox TTH_TEX_FN("\\tthpsfile#tthdrop1",1);
  This code needs to be changed to behave like \leavevmode\hbox
  in that it stacks boxes horizontally. 
@@ -16019,7 +16021,7 @@ case 35:
  of TeX's behaviour. However, a \vbox ought to do it.*/
 case 36:
 YY_RULE_SETUP
-#line 1247 "tth.lex"
+#line 1249 "tth.lex"
 {
     {
       if(tth_debug&32)fprintf(stderr,"Calling tthpsfile %s\n",yytext);
@@ -16029,12 +16031,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 1253 "tth.lex"
+#line 1255 "tth.lex"
 TTH_TEX_FN("\\tthpsfile#tthdrop1",1);
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 1254 "tth.lex"
+#line 1256 "tth.lex"
 {
   /*if(horizmode)*/ horizmode=1;
   js2=indexkey("#1",margkeys,&margmax);
@@ -16057,7 +16059,7 @@ YY_RULE_SETUP
 /* Starting State for Constructing head/body and title.*/
 case 39:
 YY_RULE_SETUP
-#line 1276 "tth.lex"
+#line 1278 "tth.lex"
 {
   fprintf(stderr,"Initial HTML output assumed to be the title.\n");
   if(tth_htmlstyle&3)strcat(tth_texclose[tth_push_depth],
@@ -16069,7 +16071,7 @@ YY_RULE_SETUP
 case 40:
 /* rule 40 can match eol */
 YY_RULE_SETUP
-#line 1283 "tth.lex"
+#line 1285 "tth.lex"
 {
   fprintf(stderr,"Initial HTML output including title.\n");
   if(tth_htmlstyle&3)strcat(tth_texclose[tth_push_depth],
@@ -16080,7 +16082,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 1290 "tth.lex"
+#line 1292 "tth.lex"
 {
   fprintf(stderr,"Initial HTML output apparently NOT the title terminates head.\n");
   if(tth_htmlstyle&3) {TTH_OUTPUT("</head>\n<body><div>\n")};
@@ -16090,12 +16092,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 1297 "tth.lex"
+#line 1299 "tth.lex"
 TTH_TEX_FN_OPT("{\\headline{#2} \\centerheader{1}{{#2}}{align=\"center\"}}#tthdrop2",2,"");
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 1299 "tth.lex"
+#line 1301 "tth.lex"
 {
   if(!tth_htmlstyle&1){
     TTH_TEX_FN_OPT("{\\headline{#2}    \\centerheader{1}{{#2}}{align=\"center\"}}#tthdrop2",2,"");
@@ -16106,7 +16108,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 1307 "tth.lex"
+#line 1309 "tth.lex"
 { 
   yy_pop_state();
   if(tth_htmlstyle&3){
@@ -16118,7 +16120,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 1316 "tth.lex"
+#line 1318 "tth.lex"
 if(!tth_htmlstyle&1){
   TTH_TEX_FN("{\\special{html:\n<title>}\\begin{notags}#1\\end{verbatim}\\special{html:</title>\n}}#tthdrop1",1);
 }else{  
@@ -16127,75 +16129,75 @@ if(!tth_htmlstyle&1){
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 1322 "tth.lex"
+#line 1324 "tth.lex"
 
 	YY_BREAK
 case 47:
 /* rule 47 can match eol */
 YY_RULE_SETUP
-#line 1323 "tth.lex"
+#line 1325 "tth.lex"
 TTH_INC_LINE;      /* Don't put spurious \par s at top.*/
 	YY_BREAK
 /* Trap some common causes of improper output in titlecheck state. */
 case 48:
-#line 1326 "tth.lex"
+#line 1328 "tth.lex"
 case 49:
 YY_RULE_SETUP
-#line 1326 "tth.lex"
+#line 1328 "tth.lex"
 {TTH_SCAN_STRING("\\title");}
 	YY_BREAK
 case 50:
-#line 1329 "tth.lex"
-case 51:
-#line 1330 "tth.lex"
-case 52:
 #line 1331 "tth.lex"
-case 53:
+case 51:
 #line 1332 "tth.lex"
-case 54:
+case 52:
 #line 1333 "tth.lex"
-case 55:
+case 53:
 #line 1334 "tth.lex"
-case 56:
+case 54:
 #line 1335 "tth.lex"
+case 55:
+#line 1336 "tth.lex"
+case 56:
+#line 1337 "tth.lex"
 case 57:
 YY_RULE_SETUP
-#line 1335 "tth.lex"
+#line 1337 "tth.lex"
 {
   sprintf(newcstr,"\\headline{#1}%s{#1}#tthdrop1",yytext);
   TTH_TEX_FN(newcstr,1);}
 	YY_BREAK
 case 58:
 /* rule 58 can match eol */
-#line 1340 "tth.lex"
+#line 1342 "tth.lex"
 case 59:
 /* rule 59 can match eol */
-#line 1341 "tth.lex"
+#line 1343 "tth.lex"
 case 60:
 /* rule 60 can match eol */
-#line 1342 "tth.lex"
+#line 1344 "tth.lex"
 case 61:
 /* rule 61 can match eol */
-#line 1343 "tth.lex"
+#line 1345 "tth.lex"
 case 62:
 /* rule 62 can match eol */
-#line 1344 "tth.lex"
+#line 1346 "tth.lex"
 case 63:
 /* rule 63 can match eol */
-#line 1345 "tth.lex"
+#line 1347 "tth.lex"
 case 64:
 /* rule 64 can match eol */
-#line 1346 "tth.lex"
+#line 1348 "tth.lex"
 case 65:
 /* rule 65 can match eol */
-#line 1347 "tth.lex"
+#line 1349 "tth.lex"
 case 66:
 /* rule 66 can match eol */
-#line 1348 "tth.lex"
+#line 1350 "tth.lex"
 case 67:
 /* rule 67 can match eol */
 YY_RULE_SETUP
-#line 1348 "tth.lex"
+#line 1350 "tth.lex"
 {
   fprintf(stderr,
 	"**** File starts with \"%s\". It can\'t be the HTML title.\n",
@@ -16209,24 +16211,24 @@ YY_RULE_SETUP
 	YY_BREAK
 /* Things that can't go in the HTML head in strict mode.*/
 case 68:
-#line 1360 "tth.lex"
-case 69:
-#line 1361 "tth.lex"
-case 70:
 #line 1362 "tth.lex"
-case 71:
+case 69:
 #line 1363 "tth.lex"
-case 72:
+case 70:
 #line 1364 "tth.lex"
-case 73:
+case 71:
 #line 1365 "tth.lex"
-case 74:
+case 72:
 #line 1366 "tth.lex"
-case 75:
+case 73:
 #line 1367 "tth.lex"
+case 74:
+#line 1368 "tth.lex"
+case 75:
+#line 1369 "tth.lex"
 case 76:
 YY_RULE_SETUP
-#line 1367 "tth.lex"
+#line 1369 "tth.lex"
 {
   fprintf(stderr,
 	  "**** File starts with \"%s\". It can\'t be in strict HTML heads.\n",
@@ -16241,7 +16243,7 @@ YY_RULE_SETUP
 /* Make the title the first one to five plain words. */
 case 77:
 YY_RULE_SETUP
-#line 1378 "tth.lex"
+#line 1380 "tth.lex"
 {
   fprintf(stderr,"HTML Title constructed as:%s\n",yytext);
   fprintf(tth_fdout,"\n<title>%s</title>\n",yytext);
@@ -16253,7 +16255,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 1386 "tth.lex"
+#line 1388 "tth.lex"
 {
   fprintf(stderr,"Pagecolor in titlecheck.\n");
   if(tth_htmlstyle&3)fprintf(tth_fdout,"<title>No title</title></head>\n");
@@ -16263,42 +16265,42 @@ YY_RULE_SETUP
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 1393 "tth.lex"
+#line 1395 "tth.lex"
 {  /*tth_num_lines--;*/
   TTH_TEX_FN("{\\special{html:\n<h#1>}#2\\special{html:</h#1>}}#tthdrop2",2); }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 1395 "tth.lex"
+#line 1397 "tth.lex"
 TTH_TEX_FN("{\\special{html:\n<h#1 #3>}#2 \\special{html:</h#1>}}#tthdrop3",3);/* tth_num_lines--;*/
 	YY_BREAK
 case 81:
-#line 1398 "tth.lex"
+#line 1400 "tth.lex"
 case 82:
 YY_RULE_SETUP
-#line 1398 "tth.lex"
+#line 1400 "tth.lex"
 {
   TTH_PUSH_CLOSING;yy_push_state(rawgroup);
  }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 1402 "tth.lex"
+#line 1404 "tth.lex"
 TTH_SCAN_STRING("\\expandafter\\tthhref\\tthescape");
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 1403 "tth.lex"
+#line 1405 "tth.lex"
 {
   TTH_TEX_FN("{\\special{html:<a href=\"#1\">}#2\\special{html:</a>}}#tthdrop2",2); 
 }
 	YY_BREAK
 /* Get the following brace group and escape special chars, rescan */
 case 85:
-#line 1408 "tth.lex"
+#line 1410 "tth.lex"
 case 86:
 YY_RULE_SETUP
-#line 1408 "tth.lex"
+#line 1410 "tth.lex"
 {
   *dupstore=0;
   *argchar=0;
@@ -16309,10 +16311,10 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 87:
-#line 1417 "tth.lex"
+#line 1419 "tth.lex"
 case 88:
 YY_RULE_SETUP
-#line 1417 "tth.lex"
+#line 1419 "tth.lex"
 {
   *dupstore=0;
   *argchar=0;
@@ -16326,7 +16328,7 @@ YY_RULE_SETUP
 case 89:
 /* rule 89 can match eol */
 YY_RULE_SETUP
-#line 1427 "tth.lex"
+#line 1429 "tth.lex"
 {
   yyless(0);
   yy_pop_state();
@@ -16335,23 +16337,23 @@ YY_RULE_SETUP
   if(strcspn(dupstore,"\\&")!=0){
   /* Even the href can't contain an ampersand literally so we need to
    translate it.*/
-    strcpy(dupstore2,dupstore);
+    strcpy(dupstore3,dupstore);
     *dupstore=0;
     i=0;
-    while(*(dupstore2+i)!=0){
-      if(*(dupstore2+i)=='&'){
+    while(*(dupstore3+i)!=0){
+      if(*(dupstore3+i)=='&'){
 	if(*(dupstore+strlen(dupstore)-1)=='\\')
 	  *(dupstore+strlen(dupstore)-1)=0;/*Remove prior  */
 	strncat(dupstore,"&amp;",5);
       }else{
-	strncat(dupstore,(dupstore2+i),1);
+	strncat(dupstore,(dupstore3+i),1);
       }
       i++;
     }
   }
   sprintf(dupstore2,
 	  "\\special{html:<a href=\"%s\">}\\verb%c%s%c\\special{html:</a>}"
-	  ,dupstore+1,6,dupstore+1,6);
+	  ,dupstore+1,6,dupstore3+1,6);
   TTH_SCAN_STRING(dupstore2);
   *dupstore=0;
   *dupstore2=0;
@@ -16359,22 +16361,22 @@ YY_RULE_SETUP
 	YY_BREAK
 /* Colordvi commands, won't work in equations. Convert to \color */
 case 90:
-#line 1459 "tth.lex"
-case 91:
-#line 1460 "tth.lex"
-case 92:
 #line 1461 "tth.lex"
-case 93:
+case 91:
 #line 1462 "tth.lex"
-case 94:
+case 92:
 #line 1463 "tth.lex"
-case 95:
+case 93:
 #line 1464 "tth.lex"
-case 96:
+case 94:
 #line 1465 "tth.lex"
+case 95:
+#line 1466 "tth.lex"
+case 96:
+#line 1467 "tth.lex"
 case 97:
 YY_RULE_SETUP
-#line 1465 "tth.lex"
+#line 1467 "tth.lex"
 {
   strcpy(scratchstring,yytext+1);
   /**scratchstring=tolower(*scratchstring);*/
@@ -16385,21 +16387,21 @@ YY_RULE_SETUP
 case 98:
 /* rule 98 can match eol */
 YY_RULE_SETUP
-#line 1471 "tth.lex"
+#line 1473 "tth.lex"
 TTH_INC_MULTI;fprintf(tth_fdout,",");
 	YY_BREAK
 /************************ Comment removal ******************/
 /* Many needed so that e.g.  inside a comment does not break stuff */
 case 99:
 /* rule 99 can match eol */
-#line 1476 "tth.lex"
+#line 1478 "tth.lex"
 case 100:
 /* rule 100 can match eol */
-#line 1477 "tth.lex"
+#line 1479 "tth.lex"
 case 101:
 /* rule 101 can match eol */
 YY_RULE_SETUP
-#line 1477 "tth.lex"
+#line 1479 "tth.lex"
 {
   TTH_INC_LINE;
   if(strstr(yytext,"%%tth:")==yytext){TTH_SCAN_STRING(yytext+6);}
@@ -16412,7 +16414,7 @@ YY_RULE_SETUP
 case 102:
 /* rule 102 can match eol */
 YY_RULE_SETUP
-#line 1486 "tth.lex"
+#line 1488 "tth.lex"
 {
   TTH_INC_LINE;
   if(strstr(yytext,"%%tth:")==yytext){TTH_SCAN_STRING(yytext+6);}
@@ -16427,20 +16429,20 @@ YY_RULE_SETUP
 /* escgroup explicitly ignores comment removal and other special chars.*/
 case 103:
 YY_RULE_SETUP
-#line 1498 "tth.lex"
+#line 1500 "tth.lex"
 strcat(dupstore,"\\");strcat(dupstore,yytext); 
 	YY_BREAK
 /* Don't escape things already escaped*/
 case 104:
 YY_RULE_SETUP
-#line 1500 "tth.lex"
+#line 1502 "tth.lex"
 strcat(dupstore,yytext); 
 	YY_BREAK
 /*********************************************************************/
 /* Date information needs to be before conditionals. */
 case 105:
 YY_RULE_SETUP
-#line 1503 "tth.lex"
+#line 1505 "tth.lex"
 {
   time(&thetime);
   strcpy(scratchstring,ctime(&thetime));
@@ -16452,7 +16454,7 @@ YY_RULE_SETUP
 /* Act as if these are counters */
 case 106:
 YY_RULE_SETUP
-#line 1512 "tth.lex"
+#line 1514 "tth.lex"
 {
   yyless(0);
   TTH_SCAN_STRING("\\number");
@@ -16460,7 +16462,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 1517 "tth.lex"
+#line 1519 "tth.lex"
 {
   time(&thetime);
   timestruct=*localtime(&thetime);
@@ -16473,7 +16475,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 1526 "tth.lex"
+#line 1528 "tth.lex"
 {
   time(&thetime);
   timestruct=*localtime(&thetime);
@@ -16484,7 +16486,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 1533 "tth.lex"
+#line 1535 "tth.lex"
 {
   time(&thetime);
   timestruct=*localtime(&thetime);
@@ -16497,7 +16499,7 @@ YY_RULE_SETUP
 /* Conditionals*/
 case 110:
 YY_RULE_SETUP
-#line 1543 "tth.lex"
+#line 1545 "tth.lex"
 {
   strcpy(scratchstring,strstr(yytext,"\\if")+3);
   sprintf(scrstring,"\\def\\if%s{\\iffalse}\\def\\%sfalse{\\%dfalse}\\def\\%strue{\\%dtrue}",scratchstring,scratchstring,nkeys,scratchstring,nkeys);
@@ -16506,7 +16508,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 1548 "tth.lex"
+#line 1550 "tth.lex"
 {
   sscanf(yytext+1,"%d",&js2);
   strncpy(defs[js2]+3,"false",5);
@@ -16514,48 +16516,48 @@ YY_RULE_SETUP
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 1552 "tth.lex"
+#line 1554 "tth.lex"
 {
   sscanf(yytext+1,"%d",&js2);
   strncpy(defs[js2]+3,"true ",5);
 }
 	YY_BREAK
 case 113:
-#line 1558 "tth.lex"
-case 114:
-#line 1559 "tth.lex"
-case 115:
 #line 1560 "tth.lex"
+case 114:
+#line 1561 "tth.lex"
+case 115:
+#line 1562 "tth.lex"
 case 116:
 YY_RULE_SETUP
-#line 1560 "tth.lex"
+#line 1562 "tth.lex"
 if(tth_debug&1024)fprintf(stderr,"Starting %s.\n",yytext);
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 1562 "tth.lex"
+#line 1564 "tth.lex"
 
 	YY_BREAK
 case 118:
-#line 1564 "tth.lex"
+#line 1566 "tth.lex"
 case 119:
 YY_RULE_SETUP
-#line 1564 "tth.lex"
+#line 1566 "tth.lex"
 {
   yy_push_state(innerfalse);
   if(tth_debug&1024)fprintf(stderr,"Starting inner \\if in falsetext.\n");
 }
 	YY_BREAK
 case 120:
-#line 1569 "tth.lex"
+#line 1571 "tth.lex"
 case 121:
 YY_RULE_SETUP
-#line 1569 "tth.lex"
+#line 1571 "tth.lex"
 
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 1570 "tth.lex"
+#line 1572 "tth.lex"
 {
   yy_push_state(falsetext);
   if(tth_debug&1024)fprintf(stderr,"Starting \\iffalse.\n");
@@ -16563,29 +16565,29 @@ YY_RULE_SETUP
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 1574 "tth.lex"
+#line 1576 "tth.lex"
 if(horizmode) yy_push_state(falsetext);
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 1575 "tth.lex"
+#line 1577 "tth.lex"
 if(!horizmode) yy_push_state(falsetext);
 	YY_BREAK
 case 125:
-#line 1578 "tth.lex"
+#line 1580 "tth.lex"
 case 126:
 YY_RULE_SETUP
-#line 1578 "tth.lex"
+#line 1580 "tth.lex"
 {
   if(tth_debug&1024)fprintf(stderr,"Ending true clause \\if\\fi.\n");
   if(horizmode)horizmode=1;
 }
 	YY_BREAK
 case 127:
-#line 1583 "tth.lex"
+#line 1585 "tth.lex"
 case 128:
 YY_RULE_SETUP
-#line 1583 "tth.lex"
+#line 1585 "tth.lex"
 {
   if(tth_debug&1024)fprintf(stderr,"Ending true clause \\if\\else\n");
   yy_push_state(falsetext);
@@ -16594,7 +16596,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 1588 "tth.lex"
+#line 1590 "tth.lex"
 {
   yy_pop_state();
   if(tth_debug&1024)fprintf(stderr,"Ending false clause \\if\\else.\n");
@@ -16604,12 +16606,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 1594 "tth.lex"
+#line 1596 "tth.lex"
 /* Don't misinterpret other commands. */
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 1595 "tth.lex"
+#line 1597 "tth.lex"
 {
   yy_pop_state(); 
   if(tth_debug&1024)fprintf(stderr,"Ending false clause \\if\\fi.\n");
@@ -16618,90 +16620,90 @@ YY_RULE_SETUP
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 1600 "tth.lex"
+#line 1602 "tth.lex"
 
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 1602 "tth.lex"
+#line 1604 "tth.lex"
 yy_push_state(innerfalse);
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 1603 "tth.lex"
+#line 1605 "tth.lex"
 yy_pop_state(); if(tth_debug&1024)fprintf(stderr,"\\or ");
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 1604 "tth.lex"
+#line 1606 "tth.lex"
 yy_push_state(innerfalse); /* Ignore nested ifs */
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 1605 "tth.lex"
+#line 1607 "tth.lex"
 {
  yy_pop_state(); if(tth_debug&1024)fprintf(stderr,"#tthorbreak\n");
  TTH_SCAN_STRING(yytext);
  }
 	YY_BREAK
 case 137:
-#line 1610 "tth.lex"
+#line 1612 "tth.lex"
 case 138:
 YY_RULE_SETUP
-#line 1610 "tth.lex"
+#line 1612 "tth.lex"
 {
   if(tth_debug&1024)fprintf(stderr,"%s ortext\n",yytext);
   TTH_SCAN_STRING("#tthorbreak");}
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 1613 "tth.lex"
+#line 1615 "tth.lex"
 /*fprintf(stderr,"ortext ");*/
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 1615 "tth.lex"
+#line 1617 "tth.lex"
 {
   yy_pop_state(); if(tth_debug&1024)fprintf(stderr,"#orbreak end\n");}
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 1617 "tth.lex"
+#line 1619 "tth.lex"
 {
   yyless(0); 
   yy_pop_state(); if(tth_debug&1024)fprintf(stderr,"Orbreak exit\n");}
 	YY_BREAK
 case 142:
-#line 1622 "tth.lex"
-case 143:
-#line 1623 "tth.lex"
-case 144:
 #line 1624 "tth.lex"
-case 145:
+case 143:
 #line 1625 "tth.lex"
-case 146:
+case 144:
 #line 1626 "tth.lex"
+case 145:
+#line 1627 "tth.lex"
+case 146:
+#line 1628 "tth.lex"
 case 147:
 YY_RULE_SETUP
-#line 1626 "tth.lex"
+#line 1628 "tth.lex"
 {
   yy_push_state(getifnum);strcpy(strif,yytext);yy_push_state(removespace);}
 	YY_BREAK
 case 148:
-#line 1629 "tth.lex"
+#line 1631 "tth.lex"
 case 149:
 YY_RULE_SETUP
-#line 1629 "tth.lex"
+#line 1631 "tth.lex"
 yy_push_state(number);jscratch=0;
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 1630 "tth.lex"
+#line 1632 "tth.lex"
 TTH_CCAT(strif,yytext);
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 1631 "tth.lex"
+#line 1633 "tth.lex"
 { 
   TTH_DO_MACRO
   else if( (ind=indexkey(yytext,countkeys,&ncounters)) != -1) { 
@@ -16716,18 +16718,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 1642 "tth.lex"
+#line 1644 "tth.lex"
 TTH_CCAT(strif,yytext);yy_push_state(removespace);
 	YY_BREAK
 case 153:
 /* rule 153 can match eol */
 YY_RULE_SETUP
-#line 1643 "tth.lex"
+#line 1645 "tth.lex"
 /*Oct 2001.*/
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 1644 "tth.lex"
+#line 1646 "tth.lex"
 {
   yy_pop_state();
   if(*yytext != '#') {yyless(0);}
@@ -16753,15 +16755,15 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 155:
-#line 1669 "tth.lex"
+#line 1671 "tth.lex"
 case 156:
 YY_RULE_SETUP
-#line 1669 "tth.lex"
+#line 1671 "tth.lex"
 yy_push_state(getiftok);*strif=0;  yy_push_state(removespace);
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 1670 "tth.lex"
+#line 1672 "tth.lex"
 { 
   TTH_DO_MACRO
   else{
@@ -16778,7 +16780,7 @@ YY_RULE_SETUP
 case 158:
 /* rule 158 can match eol */
 YY_RULE_SETUP
-#line 1682 "tth.lex"
+#line 1684 "tth.lex"
 {
   if(strcspn(yytext,"\n")==0) TTH_INC_LINE;
   if(strlen(strif)){
@@ -16789,19 +16791,19 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 159:
-#line 1692 "tth.lex"
+#line 1694 "tth.lex"
 case 160:
 YY_RULE_SETUP
-#line 1692 "tth.lex"
+#line 1694 "tth.lex"
 yy_push_state(getifx);*strif=0;  yy_push_state(removespace);
 	YY_BREAK
 case 161:
 /* rule 161 can match eol */
-#line 1694 "tth.lex"
+#line 1696 "tth.lex"
 case 162:
 /* rule 162 can match eol */
 YY_RULE_SETUP
-#line 1694 "tth.lex"
+#line 1696 "tth.lex"
 {
   if(strcspn(yytext,"\n")==0) TTH_INC_LINE;
   if(tth_debug&1024) fprintf(stderr,"\\ifx comparison argument:%s\n",yytext);
@@ -16836,7 +16838,7 @@ YY_RULE_SETUP
 /*equationhl*/
 case 163:
 YY_RULE_SETUP
-#line 1725 "tth.lex"
+#line 1727 "tth.lex"
 { 
   if(!eqalignrow) mkkey(eqstr,eqstrs,&eqdepth);       /* Start new row */ 
   if(tth_istyle&1)eqalignrow=eqalignrow+6*(levhgt[eqclose]-1)+TTH_HGT;else
@@ -16847,7 +16849,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 1733 "tth.lex"
+#line 1735 "tth.lex"
 {
   TTH_TEX_FN("{\\buildrel{#1}\\over{#2}}#tthdrop2",2);
 }
@@ -16855,13 +16857,13 @@ YY_RULE_SETUP
 case 165:
 /* rule 165 can match eol */
 YY_RULE_SETUP
-#line 1737 "tth.lex"
+#line 1739 "tth.lex"
 TTH_CHECK_LENGTH;  TTH_INC_LINE;
 	YY_BREAK
 case 166:
 /* rule 166 can match eol */
 YY_RULE_SETUP
-#line 1739 "tth.lex"
+#line 1741 "tth.lex"
 {
   TTH_INC_MULTI;
   if(*halstring){ /* halign and tabular */
@@ -16874,12 +16876,12 @@ YY_RULE_SETUP
 /* Version that uses tabular code: */
 case 167:
 YY_RULE_SETUP
-#line 1749 "tth.lex"
+#line 1751 "tth.lex"
 TTH_SCAN_STRING("\\end{tabular}");
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 1751 "tth.lex"
+#line 1753 "tth.lex"
 {
   if(tth_debug&2)fprintf(stderr,"end eqnarray, eqdepth=%d, eqclose=%d, tth_multinum=%d, eqalignlog=%d.\n",eqdepth,eqclose,tth_multinum,eqalignlog);
   TTH_SCAN_STRING("}}\\tth_endeqnarray"); 
@@ -16887,61 +16889,61 @@ YY_RULE_SETUP
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 1755 "tth.lex"
+#line 1757 "tth.lex"
 if(eqalignlog <= 100) eqalignlog=eqalignlog+100;
 	YY_BREAK
 /* Font faces and styles etc.*/
 case 170:
 YY_RULE_SETUP
-#line 1757 "tth.lex"
+#line 1759 "tth.lex"
 TTH_SWAP("\\rm ");
 	YY_BREAK
 case 171:
-#line 1759 "tth.lex"
+#line 1761 "tth.lex"
 case 172:
 YY_RULE_SETUP
-#line 1759 "tth.lex"
+#line 1761 "tth.lex"
 TTH_SWAP("\\bf ");
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 1760 "tth.lex"
+#line 1762 "tth.lex"
 TTH_SWAP("\\it ");
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 1761 "tth.lex"
+#line 1763 "tth.lex"
 TTH_SWAP("\\it ");
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 1762 "tth.lex"
+#line 1764 "tth.lex"
 TTH_SWAP("\\tt ");
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 1763 "tth.lex"
+#line 1765 "tth.lex"
 TTH_SWAP("\\sffamily ");
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 1764 "tth.lex"
+#line 1766 "tth.lex"
 
 	YY_BREAK
 case 178:
 /* rule 178 can match eol */
 YY_RULE_SETUP
-#line 1765 "tth.lex"
+#line 1767 "tth.lex"
 TTH_INC_MULTI; 
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 1766 "tth.lex"
+#line 1768 "tth.lex"
 TTH_MATHI(219);
 	YY_BREAK
 case 180:
 YY_RULE_SETUP
-#line 1769 "tth.lex"
+#line 1771 "tth.lex"
 {
  /* halign */
   /*if(*halstring) {TTH_SCAN_STRING("}\\tth_mhamper{");*/
@@ -16952,20 +16954,20 @@ YY_RULE_SETUP
 	YY_BREAK
 case 181:
 YY_RULE_SETUP
-#line 1776 "tth.lex"
+#line 1778 "tth.lex"
 yy_push_state(hamper);
 	YY_BREAK
 /* hamper for halign */
 case 182:
 /* rule 182 can match eol */
 YY_RULE_SETUP
-#line 1779 "tth.lex"
+#line 1781 "tth.lex"
 TTH_INC_MULTI;  
 	YY_BREAK
 case 183:
 /* rule 183 can match eol */
 YY_RULE_SETUP
-#line 1780 "tth.lex"
+#line 1782 "tth.lex"
 {  
   yyless(0);yy_pop_state();
   tth_enclose(TTH_EQA1,eqstr,TTH_EQA2,eqstore);
@@ -16984,18 +16986,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 184:
 YY_RULE_SETUP
-#line 1796 "tth.lex"
+#line 1798 "tth.lex"
 TTH_TEX_FN("\\tthemultispan{#1}#tthdrop1",1);
 	YY_BREAK
 case 185:
 YY_RULE_SETUP
-#line 1797 "tth.lex"
+#line 1799 "tth.lex"
 TTH_TEX_FN("\\tthemultispan{#1}#tthdrop2",2);
 	YY_BREAK
 /*  interior in array */
 case 186:
 YY_RULE_SETUP
-#line 1799 "tth.lex"
+#line 1801 "tth.lex"
 {
   yy_pop_state();  
   chscratch=strstr(yytext,"multi");
@@ -17014,7 +17016,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 187:
 YY_RULE_SETUP
-#line 1814 "tth.lex"
+#line 1816 "tth.lex"
 { /* line start in array */
   chscratch=strstr(yytext,"multi");
   TTH_CCPY(argchar,chscratch+strcspn(chscratch,"{")+1);
@@ -17024,7 +17026,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 188:
 YY_RULE_SETUP
-#line 1820 "tth.lex"
+#line 1822 "tth.lex"
 { /* expand first */
   TTH_DO_MACRO
   else{
@@ -17046,7 +17048,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 189:
 YY_RULE_SETUP
-#line 1839 "tth.lex"
+#line 1841 "tth.lex"
 { 
   if(tth_debug&33) fprintf(stderr,"noalign in equation:\n");
   if(!eqalignrow) mkkey(eqstr,eqstrs,&eqdepth);
@@ -17059,14 +17061,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 190:
 /* rule 190 can match eol */
-#line 1849 "tth.lex"
+#line 1851 "tth.lex"
 case 191:
 /* rule 191 can match eol */
-#line 1850 "tth.lex"
+#line 1852 "tth.lex"
 case 192:
 /* rule 192 can match eol */
 YY_RULE_SETUP
-#line 1850 "tth.lex"
+#line 1852 "tth.lex"
 {  
   if(eqclose && (active[eqclose-1] || mtrx[eqclose-1])){ 
     /* If this is really an array-type environment. */
@@ -17121,7 +17123,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 193:
 YY_RULE_SETUP
-#line 1902 "tth.lex"
+#line 1904 "tth.lex"
 {
   if(tth_LaTeX && tth_multinum && strlen(envirchar) && (eqalignlog==1) ){
     equatno++;sprintf(envirchar,"%d",equatno);tth_multinum++;
@@ -17142,7 +17144,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 194:
 YY_RULE_SETUP
-#line 1920 "tth.lex"
+#line 1922 "tth.lex"
 {
   if(tth_debug&16) {
     fprintf(stderr,"Start Group {, eqdepth=%d, eqclose=%d, tth_flev=%d, levdelim=%s\n",eqdepth,eqclose,tth_flev,levdelim[eqclose]);
@@ -17158,7 +17160,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 195:
 YY_RULE_SETUP
-#line 1933 "tth.lex"
+#line 1935 "tth.lex"
 {
   if(mtrx[eqclose-1] || active[eqclose-1] || tophgt[eqclose]){
     /* Terminate getsubp state */
@@ -17171,10 +17173,10 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 196:
-#line 1944 "tth.lex"
+#line 1946 "tth.lex"
 case 197:
 YY_RULE_SETUP
-#line 1944 "tth.lex"
+#line 1946 "tth.lex"
 { 
   TTH_TEXCLOSE else{
   do{
@@ -17276,7 +17278,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 198:
 YY_RULE_SETUP
-#line 2043 "tth.lex"
+#line 2045 "tth.lex"
 {  /* Cope with ambiguous style at equation end */
   if(displaystyle){
     if(tth_debug&2)fprintf(stderr,"$$ in displaystyle\n");
@@ -17289,7 +17291,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 199:
 YY_RULE_SETUP
-#line 2053 "tth.lex"
+#line 2055 "tth.lex"
 {
   TTH_TEXCLOSE else{
     if(tth_debug&2) fprintf(stderr,"Leaving inline eq, eqclose=%d, eqdepth=%d, tth_flev=%d, levhgt=%d, tophgt=%d\n",  
@@ -17320,7 +17322,7 @@ YY_RULE_SETUP
 /* Force all equations to end enclosed. */
 case 200:
 YY_RULE_SETUP
-#line 2080 "tth.lex"
+#line 2082 "tth.lex"
 { 
   if(strstr(yytext,"*")==NULL){    /* end{equation} */
     if(tth_multinum < 2) { 
@@ -17334,15 +17336,15 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 201:
-#line 2092 "tth.lex"
+#line 2094 "tth.lex"
 case 202:
 YY_RULE_SETUP
-#line 2092 "tth.lex"
+#line 2094 "tth.lex"
 TTH_SCAN_STRING("}\\tth_endequation");
 	YY_BREAK
 case 203:
 YY_RULE_SETUP
-#line 2094 "tth.lex"
+#line 2096 "tth.lex"
 {
       strcat(eqstr,TTH_DISP3);
       TTH_SCAN_STRING("(\\theequation)\\tth_endnumbered");
@@ -17350,14 +17352,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 204:
 YY_RULE_SETUP
-#line 2098 "tth.lex"
+#line 2100 "tth.lex"
 equatno--;TTH_SCAN_STRING("\\tth_endequation");
 	YY_BREAK
 case 205:
-#line 2100 "tth.lex"
+#line 2102 "tth.lex"
 case 206:
 YY_RULE_SETUP
-#line 2100 "tth.lex"
+#line 2102 "tth.lex"
 {
   TTH_TEXCLOSE else{
   eqaligncell=0;
@@ -17409,7 +17411,7 @@ YY_RULE_SETUP
 case 207:
 /* rule 207 can match eol */
 YY_RULE_SETUP
-#line 2147 "tth.lex"
+#line 2149 "tth.lex"
 {
   if(active[eqclose]){ /* reembrace to protect active closure */
     TTH_INC_MULTI; 
@@ -17434,7 +17436,7 @@ YY_RULE_SETUP
 case 208:
 /* rule 208 can match eol */
 YY_RULE_SETUP
-#line 2168 "tth.lex"
+#line 2170 "tth.lex"
 {
   TTH_INC_MULTI; 
   yyless(strspn(yytext," \t\r\n"));
@@ -17443,7 +17445,7 @@ YY_RULE_SETUP
 case 209:
 /* rule 209 can match eol */
 YY_RULE_SETUP
-#line 2172 "tth.lex"
+#line 2174 "tth.lex"
 {
   TTH_INC_MULTI; 
   if(tth_debug&16)fprintf(stderr,
@@ -17474,7 +17476,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 210:
 YY_RULE_SETUP
-#line 2199 "tth.lex"
+#line 2201 "tth.lex"
 strcpy(levdelim[eqclose+1],")");
 	YY_BREAK
 /*TTH_SCAN_STRING("\\right)"); doesn't work. Imbalances closures.*/
@@ -17484,12 +17486,12 @@ strcpy(levdelim[eqclose+1],")");
    This case will not be used if we are doing a full cell (getsubsup). */
 case 211:
 YY_RULE_SETUP
-#line 2207 "tth.lex"
+#line 2209 "tth.lex"
 TTH_MATHI(162); 
 	YY_BREAK
 case 212:
 YY_RULE_SETUP
-#line 2208 "tth.lex"
+#line 2210 "tth.lex"
 {
   strcat(eqstr,TTH_SUP1);yy_push_state(exptokarg);
   TTH_CCPY(expchar,TTH_SUP2);
@@ -17497,7 +17499,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 213:
 YY_RULE_SETUP
-#line 2212 "tth.lex"
+#line 2214 "tth.lex"
 {
   strcat(eqstr,TTH_SUB1);yy_push_state(exptokarg);
   TTH_CCPY(expchar,TTH_SUB2);
@@ -17507,7 +17509,7 @@ YY_RULE_SETUP
 case 214:
 /* rule 214 can match eol */
 YY_RULE_SETUP
-#line 2217 "tth.lex"
+#line 2219 "tth.lex"
 {
   TTH_INC_MULTI; 
   TTH_SCAN_STRING("\\begin{tabular}");
@@ -17515,11 +17517,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 215:
 /* rule 215 can match eol */
-#line 2222 "tth.lex"
+#line 2224 "tth.lex"
 case 216:
 /* rule 216 can match eol */
 YY_RULE_SETUP
-#line 2222 "tth.lex"
+#line 2224 "tth.lex"
 { /*border not really supported*/
   TTH_INC_MULTI; 
   TTH_HAL_PUSH;*halstring=0;
@@ -17552,7 +17554,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 217:
 YY_RULE_SETUP
-#line 2251 "tth.lex"
+#line 2253 "tth.lex"
 {
   if(tth_debug&16) fprintf(stderr,"Matrix close %d, levhgt=%d, rows=%d\n",
 			   eqclose,levhgt[eqclose],eqalignrow);
@@ -17574,14 +17576,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 218:
 YY_RULE_SETUP
-#line 2270 "tth.lex"
+#line 2272 "tth.lex"
 {
   TTH_TEX_FN("\\mbox{\\left\\lbrace\\matrix{#1}\\right.}#tthdrop1",1);
 }
 	YY_BREAK
 case 219:
 YY_RULE_SETUP
-#line 2273 "tth.lex"
+#line 2275 "tth.lex"
 {
   TTH_TEX_FN("\\left(\\matrix{#1}\\right)#tthdrop1",1);
 }
@@ -17593,20 +17595,20 @@ YY_RULE_SETUP
  */
 case 220:
 /* rule 220 can match eol */
-#line 2283 "tth.lex"
+#line 2285 "tth.lex"
 case 221:
 /* rule 221 can match eol */
-#line 2284 "tth.lex"
+#line 2286 "tth.lex"
 case 222:
 /* rule 222 can match eol */
-#line 2285 "tth.lex"
+#line 2287 "tth.lex"
 case 223:
 /* rule 223 can match eol */
-#line 2286 "tth.lex"
+#line 2288 "tth.lex"
 case 224:
 /* rule 224 can match eol */
 YY_RULE_SETUP
-#line 2286 "tth.lex"
+#line 2288 "tth.lex"
 {
   TTH_INC_MULTI;
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\rm ");  TTH_SCAN_STRING("\\tth_tbox");
@@ -17614,44 +17616,44 @@ YY_RULE_SETUP
 	YY_BREAK
 case 225:
 YY_RULE_SETUP
-#line 2290 "tth.lex"
+#line 2292 "tth.lex"
 {
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\bf ");  TTH_SCAN_STRING("\\tth_tbox");
 }
 	YY_BREAK
 case 226:
-#line 2294 "tth.lex"
+#line 2296 "tth.lex"
 case 227:
 YY_RULE_SETUP
-#line 2294 "tth.lex"
+#line 2296 "tth.lex"
 {
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\it ");  TTH_SCAN_STRING("\\tth_tbox");
 }
 	YY_BREAK
 case 228:
 YY_RULE_SETUP
-#line 2297 "tth.lex"
+#line 2299 "tth.lex"
 {
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\tt ");  TTH_SCAN_STRING("\\tth_tbox");
 }
 	YY_BREAK
 case 229:
 YY_RULE_SETUP
-#line 2300 "tth.lex"
+#line 2302 "tth.lex"
 {
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\sffamily ");  TTH_SCAN_STRING("\\tth_tbox");
 }
 	YY_BREAK
 case 230:
 YY_RULE_SETUP
-#line 2303 "tth.lex"
+#line 2305 "tth.lex"
 {
   strcpy(scratchstring,"\\tth_tbone");strcat(scratchstring,"\\scshape ");  TTH_SCAN_STRING("\\tth_tbox");
 }
 	YY_BREAK
 case 231:
 YY_RULE_SETUP
-#line 2306 "tth.lex"
+#line 2308 "tth.lex"
 {
   if(tth_debug&2)fprintf(stderr,
     "Start textbox. eqclose %d. push_depth %d. Line %d\n"
@@ -17664,7 +17666,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 232:
 YY_RULE_SETUP
-#line 2315 "tth.lex"
+#line 2317 "tth.lex"
 {
   if(tth_debug&2)fprintf(stderr,
       "Start textbox exptokarg. Displaystyle %d. eqclose %d, push_depth %d, Line %d\n"
@@ -17677,7 +17679,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 233:
 YY_RULE_SETUP
-#line 2324 "tth.lex"
+#line 2326 "tth.lex"
 { /* box closure*/
     if(tth_debug&2) fprintf(stderr,"Box closure, eqclose=%d\n",eqclose);
     if(!displaystyle) yy_pop_state(); /* textbox state end */
@@ -17685,7 +17687,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 234:
 YY_RULE_SETUP
-#line 2328 "tth.lex"
+#line 2330 "tth.lex"
 {
   if(tth_debug&8)fprintf(stderr,"tbone at push_depth %d\n",tth_push_depth);
   TTH_OUTPUT(TTH_TEXTBOX1);
@@ -17694,16 +17696,16 @@ YY_RULE_SETUP
 	YY_BREAK
 case 235:
 YY_RULE_SETUP
-#line 2333 "tth.lex"
+#line 2335 "tth.lex"
 {GET_DIMEN;} /* Override new handling */
 	YY_BREAK
 case 236:
-#line 2336 "tth.lex"
+#line 2338 "tth.lex"
 case 237:
-#line 2337 "tth.lex"
+#line 2339 "tth.lex"
 case 238:
 YY_RULE_SETUP
-#line 2337 "tth.lex"
+#line 2339 "tth.lex"
 {
   /* Deal with single $ or inline in display equations or boxes.*/
   if(displaystyle==1){ /* Open inline in box enclose it.*/
@@ -17734,33 +17736,33 @@ YY_RULE_SETUP
 /* Math greek and symbols */
 case 239:
 YY_RULE_SETUP
-#line 2364 "tth.lex"
+#line 2366 "tth.lex"
 TTH_MATHS("a");
 	YY_BREAK
 case 240:
 YY_RULE_SETUP
-#line 2365 "tth.lex"
+#line 2367 "tth.lex"
 TTH_MATHS("b");
 	YY_BREAK
 case 241:
 YY_RULE_SETUP
-#line 2366 "tth.lex"
+#line 2368 "tth.lex"
 TTH_MATHS("g");
 	YY_BREAK
 case 242:
 YY_RULE_SETUP
-#line 2367 "tth.lex"
+#line 2369 "tth.lex"
 TTH_MATHS("d");
 	YY_BREAK
 case 243:
 YY_RULE_SETUP
-#line 2368 "tth.lex"
+#line 2370 "tth.lex"
 TTH_MATHS("e");
 	YY_BREAK
 /* <equation>\\varepsilon{SP}*	TTH_MATHS("e"); */ 
 case 244:
 YY_RULE_SETUP
-#line 2370 "tth.lex"
+#line 2372 "tth.lex"
 {
   if(tth_unicode){
     TTH_MATHI(129); /*Kludge for coding translation */
@@ -17771,516 +17773,516 @@ YY_RULE_SETUP
 	YY_BREAK
 case 245:
 YY_RULE_SETUP
-#line 2377 "tth.lex"
+#line 2379 "tth.lex"
 TTH_MATHS("z");
 	YY_BREAK
 case 246:
 YY_RULE_SETUP
-#line 2378 "tth.lex"
+#line 2380 "tth.lex"
 TTH_MATHS("h")
 	YY_BREAK
 case 247:
 YY_RULE_SETUP
-#line 2379 "tth.lex"
+#line 2381 "tth.lex"
 TTH_MATHS("q");
 	YY_BREAK
 case 248:
 YY_RULE_SETUP
-#line 2380 "tth.lex"
+#line 2382 "tth.lex"
 TTH_MATHS("J");
 	YY_BREAK
 case 249:
 YY_RULE_SETUP
-#line 2381 "tth.lex"
+#line 2383 "tth.lex"
 TTH_MATHS("i");
 	YY_BREAK
 case 250:
 YY_RULE_SETUP
-#line 2382 "tth.lex"
+#line 2384 "tth.lex"
 TTH_MATHS("k");
 	YY_BREAK
 case 251:
 YY_RULE_SETUP
-#line 2383 "tth.lex"
+#line 2385 "tth.lex"
 TTH_MATHS("l");
 	YY_BREAK
 case 252:
 YY_RULE_SETUP
-#line 2384 "tth.lex"
+#line 2386 "tth.lex"
 TTH_MATHS("l");
 	YY_BREAK
 case 253:
 YY_RULE_SETUP
-#line 2385 "tth.lex"
+#line 2387 "tth.lex"
 TTH_MATHS("m");
 	YY_BREAK
 case 254:
 YY_RULE_SETUP
-#line 2386 "tth.lex"
+#line 2388 "tth.lex"
 TTH_MATHS("n");
 	YY_BREAK
 case 255:
 YY_RULE_SETUP
-#line 2387 "tth.lex"
+#line 2389 "tth.lex"
 TTH_MATHS("x");
 	YY_BREAK
 case 256:
 YY_RULE_SETUP
-#line 2388 "tth.lex"
+#line 2390 "tth.lex"
 TTH_MATHS("p");
 	YY_BREAK
 case 257:
 YY_RULE_SETUP
-#line 2389 "tth.lex"
+#line 2391 "tth.lex"
 TTH_MATHS("v");
 	YY_BREAK
 case 258:
 YY_RULE_SETUP
-#line 2390 "tth.lex"
+#line 2392 "tth.lex"
 TTH_MATHS("r");
 	YY_BREAK
 case 259:
 YY_RULE_SETUP
-#line 2391 "tth.lex"
+#line 2393 "tth.lex"
 TTH_MATHS("r");
 	YY_BREAK
 case 260:
 YY_RULE_SETUP
-#line 2392 "tth.lex"
+#line 2394 "tth.lex"
 TTH_MATHS("s");
 	YY_BREAK
 case 261:
 YY_RULE_SETUP
-#line 2393 "tth.lex"
+#line 2395 "tth.lex"
 TTH_MATHS("V");
 	YY_BREAK
 case 262:
 YY_RULE_SETUP
-#line 2394 "tth.lex"
+#line 2396 "tth.lex"
 TTH_MATHS("t");
 	YY_BREAK
 case 263:
 YY_RULE_SETUP
-#line 2395 "tth.lex"
+#line 2397 "tth.lex"
 TTH_MATHS("u");
 	YY_BREAK
 case 264:
 YY_RULE_SETUP
-#line 2396 "tth.lex"
+#line 2398 "tth.lex"
 TTH_MATHS("f");
 	YY_BREAK
 case 265:
 YY_RULE_SETUP
-#line 2397 "tth.lex"
+#line 2399 "tth.lex"
 TTH_MATHS("j");
 	YY_BREAK
 case 266:
 YY_RULE_SETUP
-#line 2398 "tth.lex"
+#line 2400 "tth.lex"
 TTH_MATHS("c");
 	YY_BREAK
 case 267:
 YY_RULE_SETUP
-#line 2399 "tth.lex"
+#line 2401 "tth.lex"
 TTH_MATHS("y");
 	YY_BREAK
 case 268:
 YY_RULE_SETUP
-#line 2400 "tth.lex"
+#line 2402 "tth.lex"
 TTH_MATHS("w");
 	YY_BREAK
 case 269:
 YY_RULE_SETUP
-#line 2401 "tth.lex"
+#line 2403 "tth.lex"
 TTH_MATHS("G");
 	YY_BREAK
 case 270:
 YY_RULE_SETUP
-#line 2402 "tth.lex"
+#line 2404 "tth.lex"
 TTH_MATHS("D");
 	YY_BREAK
 case 271:
 YY_RULE_SETUP
-#line 2403 "tth.lex"
+#line 2405 "tth.lex"
 TTH_MATHS("Q");
 	YY_BREAK
 case 272:
 YY_RULE_SETUP
-#line 2404 "tth.lex"
+#line 2406 "tth.lex"
 TTH_MATHS("L");
 	YY_BREAK
 case 273:
 YY_RULE_SETUP
-#line 2405 "tth.lex"
+#line 2407 "tth.lex"
 TTH_MATHS("X");
 	YY_BREAK
 case 274:
 YY_RULE_SETUP
-#line 2406 "tth.lex"
+#line 2408 "tth.lex"
 TTH_MATHS("P");
 	YY_BREAK
 case 275:
 YY_RULE_SETUP
-#line 2407 "tth.lex"
+#line 2409 "tth.lex"
 TTH_MATHS("S");
 	YY_BREAK
 case 276:
 YY_RULE_SETUP
-#line 2408 "tth.lex"
+#line 2410 "tth.lex"
 TTH_MATHS("U");
 	YY_BREAK
 case 277:
 YY_RULE_SETUP
-#line 2409 "tth.lex"
+#line 2411 "tth.lex"
 TTH_MATHS("F");
 	YY_BREAK
 case 278:
 YY_RULE_SETUP
-#line 2410 "tth.lex"
+#line 2412 "tth.lex"
 TTH_MATHS("Y");
 	YY_BREAK
 case 279:
 YY_RULE_SETUP
-#line 2411 "tth.lex"
+#line 2413 "tth.lex"
 TTH_MATHS("W");
 	YY_BREAK
 case 280:
 YY_RULE_SETUP
-#line 2413 "tth.lex"
+#line 2415 "tth.lex"
 TTH_MATHC("<i>l</i>");
 	YY_BREAK
 case 281:
 YY_RULE_SETUP
-#line 2414 "tth.lex"
+#line 2416 "tth.lex"
 TTH_MATHI(192);
 	YY_BREAK
 case 282:
 YY_RULE_SETUP
-#line 2415 "tth.lex"
+#line 2417 "tth.lex"
 TTH_MATHS("i"); 
 	YY_BREAK
 case 283:
 YY_RULE_SETUP
-#line 2416 "tth.lex"
+#line 2418 "tth.lex"
 TTH_MATHC("j"); 
 	YY_BREAK
 case 284:
 YY_RULE_SETUP
-#line 2417 "tth.lex"
+#line 2419 "tth.lex"
 TTH_MATHI(195);
 	YY_BREAK
 case 285:
-#line 2419 "tth.lex"
+#line 2421 "tth.lex"
 case 286:
 YY_RULE_SETUP
-#line 2419 "tth.lex"
+#line 2421 "tth.lex"
 TTH_MATHI(194);
 	YY_BREAK
 case 287:
-#line 2421 "tth.lex"
+#line 2423 "tth.lex"
 case 288:
 YY_RULE_SETUP
-#line 2421 "tth.lex"
+#line 2423 "tth.lex"
 TTH_MATHI(193);
 	YY_BREAK
 case 289:
 YY_RULE_SETUP
-#line 2422 "tth.lex"
+#line 2424 "tth.lex"
 TTH_MATHI(182);
 	YY_BREAK
 case 290:
 YY_RULE_SETUP
-#line 2423 "tth.lex"
+#line 2425 "tth.lex"
 TTH_MATHI(165);
 	YY_BREAK
 case 291:
 YY_RULE_SETUP
-#line 2424 "tth.lex"
+#line 2426 "tth.lex"
 TTH_MATHI(208);
 	YY_BREAK
 case 292:
 YY_RULE_SETUP
-#line 2425 "tth.lex"
+#line 2427 "tth.lex"
 TTH_MATHI(162);
 	YY_BREAK
 case 293:
 YY_RULE_SETUP
-#line 2426 "tth.lex"
+#line 2428 "tth.lex"
 TTH_MATHI(162);
 	YY_BREAK
 case 294:
 YY_RULE_SETUP
-#line 2427 "tth.lex"
+#line 2429 "tth.lex"
 TTH_MATHI(198);
 	YY_BREAK
 case 295:
 YY_RULE_SETUP
-#line 2428 "tth.lex"
+#line 2430 "tth.lex"
 TTH_MATHI(209);
 	YY_BREAK
 case 296:
 YY_RULE_SETUP
-#line 2429 "tth.lex"
+#line 2431 "tth.lex"
 TTH_MATHI(214);
 	YY_BREAK
 case 297:
-#line 2431 "tth.lex"
+#line 2433 "tth.lex"
 case 298:
 YY_RULE_SETUP
-#line 2431 "tth.lex"
+#line 2433 "tth.lex"
 TTH_MATHS("|");
 	YY_BREAK
 case 299:
-#line 2433 "tth.lex"
+#line 2435 "tth.lex"
 case 300:
-#line 2434 "tth.lex"
+#line 2436 "tth.lex"
 case 301:
 YY_RULE_SETUP
-#line 2434 "tth.lex"
+#line 2436 "tth.lex"
 TTH_MATHS("||");
 	YY_BREAK
 case 302:
 YY_RULE_SETUP
-#line 2435 "tth.lex"
+#line 2437 "tth.lex"
 TTH_MATHC("[");
 	YY_BREAK
 case 303:
 YY_RULE_SETUP
-#line 2436 "tth.lex"
+#line 2438 "tth.lex"
 TTH_MATHC("]");
 	YY_BREAK
 case 304:
 YY_RULE_SETUP
-#line 2437 "tth.lex"
+#line 2439 "tth.lex"
 TTH_MATHC("{");
 	YY_BREAK
 case 305:
 YY_RULE_SETUP
-#line 2438 "tth.lex"
+#line 2440 "tth.lex"
 TTH_MATHC("}");
 	YY_BREAK
 case 306:
 YY_RULE_SETUP
-#line 2439 "tth.lex"
+#line 2441 "tth.lex"
 TTH_MATHI(249);
 	YY_BREAK
 case 307:
 YY_RULE_SETUP
-#line 2440 "tth.lex"
+#line 2442 "tth.lex"
 TTH_MATHI(251);
 	YY_BREAK
 case 308:
 YY_RULE_SETUP
-#line 2441 "tth.lex"
+#line 2443 "tth.lex"
 TTH_MATHI(233);
 	YY_BREAK
 case 309:
 YY_RULE_SETUP
-#line 2442 "tth.lex"
+#line 2444 "tth.lex"
 TTH_MATHI(235);
 	YY_BREAK
 case 310:
 YY_RULE_SETUP
-#line 2443 "tth.lex"
+#line 2445 "tth.lex"
 TTH_MATHI(225);
 	YY_BREAK
 case 311:
 YY_RULE_SETUP
-#line 2444 "tth.lex"
+#line 2446 "tth.lex"
 TTH_MATHI(241);
 	YY_BREAK
 case 312:
-#line 2446 "tth.lex"
+#line 2448 "tth.lex"
 case 313:
-#line 2447 "tth.lex"
+#line 2449 "tth.lex"
 case 314:
 YY_RULE_SETUP
-#line 2447 "tth.lex"
+#line 2449 "tth.lex"
 TTH_MATHC("\\"); 
 	YY_BREAK
 case 315:
 YY_RULE_SETUP
-#line 2448 "tth.lex"
+#line 2450 "tth.lex"
 TTH_MATHS("\"");
 	YY_BREAK
 case 316:
 YY_RULE_SETUP
-#line 2449 "tth.lex"
+#line 2451 "tth.lex"
 TTH_MATHS("$");
 	YY_BREAK
 case 317:
 YY_RULE_SETUP
-#line 2450 "tth.lex"
+#line 2452 "tth.lex"
 TTH_MATHI(216);
 	YY_BREAK
 case 318:
 YY_RULE_SETUP
-#line 2451 "tth.lex"
+#line 2453 "tth.lex"
 TTH_MATHI(167);
 	YY_BREAK
 case 319:
 YY_RULE_SETUP
-#line 2452 "tth.lex"
+#line 2454 "tth.lex"
 TTH_MATHI(168);
 	YY_BREAK
 case 320:
 YY_RULE_SETUP
-#line 2453 "tth.lex"
+#line 2455 "tth.lex"
 TTH_MATHI(169);
 	YY_BREAK
 case 321:
 YY_RULE_SETUP
-#line 2454 "tth.lex"
+#line 2456 "tth.lex"
 TTH_MATHI(170);
 	YY_BREAK
 case 322:
 YY_RULE_SETUP
-#line 2456 "tth.lex"
+#line 2458 "tth.lex"
 TTH_MATHS("-");
 	YY_BREAK
 /*Risky. <equation>\+      TTH_MATHS("+"); */
 case 323:
 YY_RULE_SETUP
-#line 2458 "tth.lex"
+#line 2460 "tth.lex"
 TTH_MATHC("T"); 
 	YY_BREAK
 case 324:
-#line 2460 "tth.lex"
+#line 2462 "tth.lex"
 case 325:
 YY_RULE_SETUP
-#line 2460 "tth.lex"
+#line 2462 "tth.lex"
 TTH_MATHS("^");
 	YY_BREAK
 case 326:
 YY_RULE_SETUP
-#line 2461 "tth.lex"
+#line 2463 "tth.lex"
 TTH_MATHI(176);
 	YY_BREAK
 case 327:
 YY_RULE_SETUP
-#line 2462 "tth.lex"
+#line 2464 "tth.lex"
 TTH_MATHC("&#126;"); 
 	YY_BREAK
 case 328:
 YY_RULE_SETUP
-#line 2463 "tth.lex"
+#line 2465 "tth.lex"
 TTH_MATHS(" ~ ");
 	YY_BREAK
 case 329:
-#line 2465 "tth.lex"
+#line 2467 "tth.lex"
 case 330:
 YY_RULE_SETUP
-#line 2465 "tth.lex"
+#line 2467 "tth.lex"
 TTH_MATHC(" mod ");
 	YY_BREAK
 case 331:
 YY_RULE_SETUP
-#line 2466 "tth.lex"
+#line 2468 "tth.lex"
 TTH_MATHC(" &lt; ");
 	YY_BREAK
 case 332:
 YY_RULE_SETUP
-#line 2467 "tth.lex"
+#line 2469 "tth.lex"
 TTH_MATHC(" &gt; ");
 	YY_BREAK
 case 333:
-#line 2469 "tth.lex"
+#line 2471 "tth.lex"
 case 334:
 YY_RULE_SETUP
-#line 2469 "tth.lex"
+#line 2471 "tth.lex"
 TTH_MATHC(" &lt;&lt; ");
 	YY_BREAK
 case 335:
-#line 2471 "tth.lex"
+#line 2473 "tth.lex"
 case 336:
 YY_RULE_SETUP
-#line 2471 "tth.lex"
+#line 2473 "tth.lex"
 TTH_MATHC(" &gt;&gt; ");
 	YY_BREAK
 case 337:
 YY_RULE_SETUP
-#line 2472 "tth.lex"
+#line 2474 "tth.lex"
 TTH_MATHS("*");
 	YY_BREAK
 case 338:
 YY_RULE_SETUP
-#line 2473 "tth.lex"
+#line 2475 "tth.lex"
 TTH_MATHS("*");
 	YY_BREAK
 case 339:
 YY_RULE_SETUP
-#line 2474 "tth.lex"
+#line 2476 "tth.lex"
 TTH_MATHI(224);
 	YY_BREAK
 case 340:
 YY_RULE_SETUP
-#line 2475 "tth.lex"
+#line 2477 "tth.lex"
 TTH_MATHI(183);
 	YY_BREAK
 case 341:
 YY_RULE_SETUP
-#line 2476 "tth.lex"
+#line 2478 "tth.lex"
 TTH_MATHC("&#183;"); 
 	YY_BREAK
 /*<equation>\\cdot	TTH_MATHI(215);*/
 case 342:
 YY_RULE_SETUP
-#line 2478 "tth.lex"
+#line 2480 "tth.lex"
 TTH_MATHI(200);
 	YY_BREAK
 case 343:
 YY_RULE_SETUP
-#line 2479 "tth.lex"
+#line 2481 "tth.lex"
 TTH_MATHI(199);
 	YY_BREAK
 case 344:
 YY_RULE_SETUP
-#line 2480 "tth.lex"
+#line 2482 "tth.lex"
 TTH_MATHI(177);
 	YY_BREAK
 case 345:
 YY_RULE_SETUP
-#line 2481 "tth.lex"
+#line 2483 "tth.lex"
 TTH_MATHS("-&#177;");
 	YY_BREAK
 case 346:
-#line 2483 "tth.lex"
+#line 2485 "tth.lex"
 case 347:
 YY_RULE_SETUP
-#line 2483 "tth.lex"
+#line 2485 "tth.lex"
 TTH_MATHI(218);
 	YY_BREAK
 case 348:
-#line 2485 "tth.lex"
+#line 2487 "tth.lex"
 case 349:
 YY_RULE_SETUP
-#line 2485 "tth.lex"
+#line 2487 "tth.lex"
 TTH_MATHI(217);
 	YY_BREAK
 case 350:
 YY_RULE_SETUP
-#line 2486 "tth.lex"
+#line 2488 "tth.lex"
 TTH_MATHI(197);
 	YY_BREAK
 case 351:
 YY_RULE_SETUP
-#line 2487 "tth.lex"
+#line 2489 "tth.lex"
 TTH_MATHI(196);
 	YY_BREAK
 case 352:
 YY_RULE_SETUP
-#line 2488 "tth.lex"
+#line 2490 "tth.lex"
 TTH_MATHI(198);
 	YY_BREAK
 case 353:
 /* rule 353 can match eol */
 YY_RULE_SETUP
-#line 2490 "tth.lex"
+#line 2492 "tth.lex"
 TTH_INC_MULTI;/* Don't mess up if it is in wrong place*/
 	YY_BREAK
 case 354:
 YY_RULE_SETUP
-#line 2491 "tth.lex"
+#line 2493 "tth.lex"
 {
   if(eqclose <= tth_flev-1 && displaystyle){
     /*If we end with a CELL3, cut it off. */
@@ -18297,7 +18299,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 355:
 YY_RULE_SETUP
-#line 2505 "tth.lex"
+#line 2507 "tth.lex"
 {
  if(eqclose > tth_flev-1 || !displaystyle ){
    TTH_MATHI(242); /* TTH_OUTPUT(" "); perhaps not */
@@ -18312,10 +18314,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 356:
-#line 2518 "tth.lex"
+#line 2520 "tth.lex"
 case 357:
 YY_RULE_SETUP
-#line 2518 "tth.lex"
+#line 2520 "tth.lex"
 {
   if(eqclose > tth_flev-1){
     TTH_MATHC("(");TTH_MATHI(242);TTH_MATHC(")");
@@ -18327,504 +18329,504 @@ YY_RULE_SETUP
 	YY_BREAK
 case 358:
 YY_RULE_SETUP
-#line 2527 "tth.lex"
+#line 2529 "tth.lex"
 TTH_LIMITOP(199);
 	YY_BREAK
 case 359:
 YY_RULE_SETUP
-#line 2528 "tth.lex"
+#line 2530 "tth.lex"
 TTH_LIMITOP(200);
 	YY_BREAK
 case 360:
 YY_RULE_SETUP
-#line 2529 "tth.lex"
+#line 2531 "tth.lex"
 TTH_LIMITOP(218);
 	YY_BREAK
 case 361:
 YY_RULE_SETUP
-#line 2530 "tth.lex"
+#line 2532 "tth.lex"
 TTH_LIMITOP(217);
 	YY_BREAK
 case 362:
 YY_RULE_SETUP
-#line 2531 "tth.lex"
+#line 2533 "tth.lex"
 TTH_LIMITOP(196);
 	YY_BREAK
 case 363:
 YY_RULE_SETUP
-#line 2532 "tth.lex"
+#line 2534 "tth.lex"
 TTH_LIMITOP(197);
 	YY_BREAK
 case 364:
 YY_RULE_SETUP
-#line 2533 "tth.lex"
+#line 2535 "tth.lex"
 TTH_LIMITOP(229);
 	YY_BREAK
 case 365:
 YY_RULE_SETUP
-#line 2534 "tth.lex"
+#line 2536 "tth.lex"
 TTH_LIMITOP(213);
 	YY_BREAK
 case 366:
 YY_RULE_SETUP
-#line 2535 "tth.lex"
+#line 2537 "tth.lex"
 TTH_LIMITOP(242);
 	YY_BREAK
 case 367:
 YY_RULE_SETUP
-#line 2536 "tth.lex"
+#line 2538 "tth.lex"
 /* Drop a limits command if not combined */
 	YY_BREAK
 case 368:
 YY_RULE_SETUP
-#line 2538 "tth.lex"
+#line 2540 "tth.lex"
 TTH_MATHI(199);
 	YY_BREAK
 case 369:
 YY_RULE_SETUP
-#line 2539 "tth.lex"
+#line 2541 "tth.lex"
 TTH_MATHI(200);
 	YY_BREAK
 case 370:
 YY_RULE_SETUP
-#line 2540 "tth.lex"
+#line 2542 "tth.lex"
 TTH_MATHI(218);
 	YY_BREAK
 case 371:
 YY_RULE_SETUP
-#line 2541 "tth.lex"
+#line 2543 "tth.lex"
 TTH_MATHI(217);
 	YY_BREAK
 case 372:
 YY_RULE_SETUP
-#line 2542 "tth.lex"
+#line 2544 "tth.lex"
 TTH_MATHI(196);
 	YY_BREAK
 case 373:
 YY_RULE_SETUP
-#line 2543 "tth.lex"
+#line 2545 "tth.lex"
 TTH_MATHI(197);
 	YY_BREAK
 case 374:
 YY_RULE_SETUP
-#line 2544 "tth.lex"
+#line 2546 "tth.lex"
 TTH_MATHI(229);
 	YY_BREAK
 case 375:
 YY_RULE_SETUP
-#line 2545 "tth.lex"
+#line 2547 "tth.lex"
 TTH_MATHI(213);
 	YY_BREAK
 case 376:
 YY_RULE_SETUP
-#line 2547 "tth.lex"
+#line 2549 "tth.lex"
 TTH_MATHI(184);
 	YY_BREAK
 case 377:
 YY_RULE_SETUP
-#line 2548 "tth.lex"
+#line 2550 "tth.lex"
 TTH_MATHC("&times;"); 
 	YY_BREAK
 /*<equation>\\times	TTH_MATHI(180);*/
 case 378:
 YY_RULE_SETUP
-#line 2550 "tth.lex"
+#line 2552 "tth.lex"
 TTH_MATHC(" &lt;~"); 
 	YY_BREAK
 case 379:
 YY_RULE_SETUP
-#line 2551 "tth.lex"
+#line 2553 "tth.lex"
 TTH_MATHC(" &gt;~"); 
 	YY_BREAK
 case 380:
 YY_RULE_SETUP
-#line 2553 "tth.lex"
+#line 2555 "tth.lex"
 TTH_MATHC(" ");TTH_MATHC("|");TTH_MATHC(" ");
 	YY_BREAK
 case 381:
 YY_RULE_SETUP
-#line 2554 "tth.lex"
+#line 2556 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(163);TTH_MATHC(" ");
 	YY_BREAK
 case 382:
 YY_RULE_SETUP
-#line 2555 "tth.lex"
+#line 2557 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(163);TTH_MATHC(" ");
 	YY_BREAK
 case 383:
 YY_RULE_SETUP
-#line 2556 "tth.lex"
+#line 2558 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(179);TTH_MATHC(" ");
 	YY_BREAK
 case 384:
 YY_RULE_SETUP
-#line 2557 "tth.lex"
+#line 2559 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(179);TTH_MATHC(" ");
 	YY_BREAK
 case 385:
 YY_RULE_SETUP
-#line 2558 "tth.lex"
+#line 2560 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(186);TTH_MATHC(" ");
 	YY_BREAK
 case 386:
 YY_RULE_SETUP
-#line 2559 "tth.lex"
+#line 2561 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(187);TTH_MATHC(" ");
 	YY_BREAK
 case 387:
-#line 2561 "tth.lex"
+#line 2563 "tth.lex"
 case 388:
 YY_RULE_SETUP
-#line 2561 "tth.lex"
+#line 2563 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(185);TTH_MATHC(" ");
 	YY_BREAK
 case 389:
 YY_RULE_SETUP
-#line 2562 "tth.lex"
+#line 2564 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(185);TTH_MATHC(" ");
 	YY_BREAK
 case 390:
 YY_RULE_SETUP
-#line 2563 "tth.lex"
+#line 2565 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(203);TTH_MATHC(" ");
 	YY_BREAK
 case 391:
 YY_RULE_SETUP
-#line 2564 "tth.lex"
+#line 2566 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(204);TTH_MATHC(" ");
 	YY_BREAK
 case 392:
 YY_RULE_SETUP
-#line 2565 "tth.lex"
+#line 2567 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(205);TTH_MATHC(" ");
 	YY_BREAK
 case 393:
 YY_RULE_SETUP
-#line 2566 "tth.lex"
+#line 2568 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(201);TTH_MATHC(" ");
 	YY_BREAK
 case 394:
 YY_RULE_SETUP
-#line 2567 "tth.lex"
+#line 2569 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(202);TTH_MATHC(" ");
 	YY_BREAK
 case 395:
 YY_RULE_SETUP
-#line 2568 "tth.lex"
+#line 2570 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(206);TTH_MATHC(" ");
 	YY_BREAK
 case 396:
-#line 2570 "tth.lex"
+#line 2572 "tth.lex"
 case 397:
 YY_RULE_SETUP
-#line 2570 "tth.lex"
+#line 2572 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(207);TTH_MATHC(" ");
 	YY_BREAK
 case 398:
-#line 2572 "tth.lex"
+#line 2574 "tth.lex"
 case 399:
 YY_RULE_SETUP
-#line 2572 "tth.lex"
+#line 2574 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(39);TTH_MATHC(" ");
 	YY_BREAK
 case 400:
-#line 2574 "tth.lex"
+#line 2576 "tth.lex"
 case 401:
 YY_RULE_SETUP
-#line 2574 "tth.lex"
+#line 2576 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(64);TTH_MATHC(" ");
 	YY_BREAK
 case 402:
 YY_RULE_SETUP
-#line 2575 "tth.lex"
+#line 2577 "tth.lex"
 TTH_MATHC(" ");TTH_MATHI(181);TTH_MATHC(" ");
 	YY_BREAK
 case 403:
-#line 2577 "tth.lex"
+#line 2579 "tth.lex"
 case 404:
 YY_RULE_SETUP
-#line 2577 "tth.lex"
+#line 2579 "tth.lex"
 TTH_MATHI(172);
 	YY_BREAK
 case 405:
 YY_RULE_SETUP
-#line 2578 "tth.lex"
+#line 2580 "tth.lex"
 TTH_MATHI(172);
 	YY_BREAK
 /* A slight kludge */
 case 406:
-#line 2581 "tth.lex"
-case 407:
-#line 2582 "tth.lex"
-case 408:
 #line 2583 "tth.lex"
+case 407:
+#line 2584 "tth.lex"
+case 408:
+#line 2585 "tth.lex"
 case 409:
 YY_RULE_SETUP
-#line 2583 "tth.lex"
+#line 2585 "tth.lex"
 TTH_MATHI(174);
 	YY_BREAK
 case 410:
 YY_RULE_SETUP
-#line 2584 "tth.lex"
+#line 2586 "tth.lex"
 TTH_MATHI(174);
 	YY_BREAK
 case 411:
 YY_RULE_SETUP
-#line 2585 "tth.lex"
+#line 2587 "tth.lex"
 TTH_MATHI(173);
 	YY_BREAK
 case 412:
 YY_RULE_SETUP
-#line 2586 "tth.lex"
+#line 2588 "tth.lex"
 TTH_MATHI(175);
 	YY_BREAK
 case 413:
 YY_RULE_SETUP
-#line 2587 "tth.lex"
+#line 2589 "tth.lex"
 TTH_MATHC(yytext);
 	YY_BREAK
 case 414:
 YY_RULE_SETUP
-#line 2588 "tth.lex"
+#line 2590 "tth.lex"
 TTH_MATHC(yytext);
 	YY_BREAK
 case 415:
-#line 2590 "tth.lex"
+#line 2592 "tth.lex"
 case 416:
 YY_RULE_SETUP
-#line 2590 "tth.lex"
+#line 2592 "tth.lex"
 TTH_MATHI(171);
 	YY_BREAK
 case 417:
 YY_RULE_SETUP
-#line 2591 "tth.lex"
+#line 2593 "tth.lex"
 TTH_MATHI(220);
 	YY_BREAK
 case 418:
 YY_RULE_SETUP
-#line 2592 "tth.lex"
+#line 2594 "tth.lex"
 TTH_MATHI(220);
 	YY_BREAK
 case 419:
 YY_RULE_SETUP
-#line 2593 "tth.lex"
+#line 2595 "tth.lex"
 TTH_MATHI(222);
 	YY_BREAK
 case 420:
 YY_RULE_SETUP
-#line 2594 "tth.lex"
+#line 2596 "tth.lex"
 TTH_MATHI(222);
 	YY_BREAK
 case 421:
 YY_RULE_SETUP
-#line 2595 "tth.lex"
+#line 2597 "tth.lex"
 TTH_MATHC(yytext);
 	YY_BREAK
 case 422:
-#line 2597 "tth.lex"
+#line 2599 "tth.lex"
 /* moved before if code <equation>\\iff TTH_MATHI(219); */
 case 423:
 YY_RULE_SETUP
-#line 2598 "tth.lex"
+#line 2600 "tth.lex"
 TTH_MATHI(219);
 	YY_BREAK
 case 424:
 YY_RULE_SETUP
-#line 2599 "tth.lex"
+#line 2601 "tth.lex"
 TTH_MATHI(221);
 	YY_BREAK
 case 425:
 YY_RULE_SETUP
-#line 2600 "tth.lex"
+#line 2602 "tth.lex"
 TTH_MATHI(223);
 	YY_BREAK
 /* <equation>\\dots{SP}*	TTH_MATHI(188); Not in math mode */
 case 426:
 YY_RULE_SETUP
-#line 2602 "tth.lex"
+#line 2604 "tth.lex"
 TTH_MATHI(188);
 	YY_BREAK
 case 427:
 YY_RULE_SETUP
-#line 2603 "tth.lex"
+#line 2605 "tth.lex"
 TTH_MATHI(188);
 	YY_BREAK
 case 428:
 YY_RULE_SETUP
-#line 2604 "tth.lex"
+#line 2606 "tth.lex"
 TTH_MATHI(188);
 	YY_BREAK
 case 429:
 YY_RULE_SETUP
-#line 2605 "tth.lex"
+#line 2607 "tth.lex"
 TTH_MATHI(188);
 	YY_BREAK
 case 430:
 YY_RULE_SETUP
-#line 2606 "tth.lex"
+#line 2608 "tth.lex"
 TTH_MATHI(188);
 	YY_BREAK
 case 431:
 YY_RULE_SETUP
-#line 2607 "tth.lex"
+#line 2609 "tth.lex"
 TTH_OUTPUT("<sup><big>&#183;</big></sup>&#183;<sub><big>&#183;</big></sub>");
 	YY_BREAK
 case 432:
 YY_RULE_SETUP
-#line 2608 "tth.lex"
+#line 2610 "tth.lex"
 TTH_OUTPUT(":");
 	YY_BREAK
 case 433:
 YY_RULE_SETUP
-#line 2609 "tth.lex"
+#line 2611 "tth.lex"
 TTH_MATHC("@");
 	YY_BREAK
 case 434:
-#line 2611 "tth.lex"
+#line 2613 "tth.lex"
 case 435:
 YY_RULE_SETUP
-#line 2611 "tth.lex"
+#line 2613 "tth.lex"
 TTH_OUTPUT(TTH_DAG);
 	YY_BREAK
 case 436:
-#line 2613 "tth.lex"
+#line 2615 "tth.lex"
 case 437:
 YY_RULE_SETUP
-#line 2613 "tth.lex"
+#line 2615 "tth.lex"
 TTH_OUTPUT(TTH_DDAG);
 	YY_BREAK
 case 438:
 YY_RULE_SETUP
-#line 2615 "tth.lex"
+#line 2617 "tth.lex"
 TTH_MATHC("arccos");  
 	YY_BREAK
 case 439:
 YY_RULE_SETUP
-#line 2616 "tth.lex"
+#line 2618 "tth.lex"
 TTH_MATHC("arcsin");  
 	YY_BREAK
 case 440:
 YY_RULE_SETUP
-#line 2617 "tth.lex"
+#line 2619 "tth.lex"
 TTH_MATHC("arctan");  
 	YY_BREAK
 case 441:
 YY_RULE_SETUP
-#line 2618 "tth.lex"
+#line 2620 "tth.lex"
 TTH_MATHC("arg");  
 	YY_BREAK
 case 442:
 YY_RULE_SETUP
-#line 2619 "tth.lex"
+#line 2621 "tth.lex"
 TTH_MATHC("cos");  
 	YY_BREAK
 case 443:
 YY_RULE_SETUP
-#line 2620 "tth.lex"
+#line 2622 "tth.lex"
 TTH_MATHC("cosh");  
 	YY_BREAK
 case 444:
 YY_RULE_SETUP
-#line 2621 "tth.lex"
+#line 2623 "tth.lex"
 TTH_MATHC("cot");  
 	YY_BREAK
 case 445:
 YY_RULE_SETUP
-#line 2622 "tth.lex"
+#line 2624 "tth.lex"
 TTH_MATHC("coth");  
 	YY_BREAK
 case 446:
 YY_RULE_SETUP
-#line 2623 "tth.lex"
+#line 2625 "tth.lex"
 TTH_MATHC("csc");  
 	YY_BREAK
 /* <equation>\\deg{SP}*        TTH_MATHC("&deg;");  Incorrect TeX */
 case 447:
 YY_RULE_SETUP
-#line 2625 "tth.lex"
+#line 2627 "tth.lex"
 TTH_MATHC("deg");
 	YY_BREAK
 case 448:
 YY_RULE_SETUP
-#line 2626 "tth.lex"
+#line 2628 "tth.lex"
 TTH_MATHC("dim");  
 	YY_BREAK
 case 449:
 YY_RULE_SETUP
-#line 2627 "tth.lex"
+#line 2629 "tth.lex"
 TTH_MATHC("exp");  
 	YY_BREAK
 case 450:
 YY_RULE_SETUP
-#line 2628 "tth.lex"
+#line 2630 "tth.lex"
 TTH_MATHC("hom");  
 	YY_BREAK
 case 451:
 YY_RULE_SETUP
-#line 2629 "tth.lex"
+#line 2631 "tth.lex"
 TTH_MATHC("ker");  
 	YY_BREAK
 case 452:
 YY_RULE_SETUP
-#line 2630 "tth.lex"
+#line 2632 "tth.lex"
 TTH_MATHC("lg");  
 	YY_BREAK
 case 453:
 YY_RULE_SETUP
-#line 2631 "tth.lex"
+#line 2633 "tth.lex"
 TTH_MATHC("ln");  
 	YY_BREAK
 case 454:
 YY_RULE_SETUP
-#line 2632 "tth.lex"
+#line 2634 "tth.lex"
 TTH_MATHC("log");  
 	YY_BREAK
 case 455:
 YY_RULE_SETUP
-#line 2633 "tth.lex"
+#line 2635 "tth.lex"
 TTH_MATHC("sec");  
 	YY_BREAK
 case 456:
 YY_RULE_SETUP
-#line 2634 "tth.lex"
+#line 2636 "tth.lex"
 TTH_MATHC("sin");  
 	YY_BREAK
 case 457:
 YY_RULE_SETUP
-#line 2635 "tth.lex"
+#line 2637 "tth.lex"
 TTH_MATHC("sinh");  
 	YY_BREAK
 case 458:
 YY_RULE_SETUP
-#line 2636 "tth.lex"
+#line 2638 "tth.lex"
 TTH_MATHC("tan");   
 	YY_BREAK
 case 459:
 YY_RULE_SETUP
-#line 2637 "tth.lex"
+#line 2639 "tth.lex"
 TTH_MATHC("tanh");  
 	YY_BREAK
 case 460:
-#line 2640 "tth.lex"
-case 461:
-#line 2641 "tth.lex"
-case 462:
 #line 2642 "tth.lex"
-case 463:
+case 461:
 #line 2643 "tth.lex"
-case 464:
+case 462:
 #line 2644 "tth.lex"
-case 465:
+case 463:
 #line 2645 "tth.lex"
-case 466:
+case 464:
 #line 2646 "tth.lex"
-case 467:
+case 465:
 #line 2647 "tth.lex"
-case 468:
+case 466:
 #line 2648 "tth.lex"
+case 467:
+#line 2649 "tth.lex"
+case 468:
+#line 2650 "tth.lex"
 case 469:
 YY_RULE_SETUP
-#line 2648 "tth.lex"
+#line 2650 "tth.lex"
 {
   if(strstr(yytext,"nolimit")){js2=0;}else{js2=1;}
   *(yytext+1+strcspn(yytext+1," \\"))=0;
@@ -18840,11 +18842,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 470:
 /* rule 470 can match eol */
-#line 2661 "tth.lex"
+#line 2663 "tth.lex"
 case 471:
 /* rule 471 can match eol */
 YY_RULE_SETUP
-#line 2661 "tth.lex"
+#line 2663 "tth.lex"
 {
  if(eqclose > tth_flev-1 || !displaystyle ){
    unput('{');
@@ -18879,7 +18881,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 472:
 YY_RULE_SETUP
-#line 2692 "tth.lex"
+#line 2694 "tth.lex"
 { /* not done eqlimited section for mathop, overbrace */
     if(tth_debug&2)fprintf(stderr,"Mathop eqlimited:%s\n",eqstr);
     if(strlen(eqlimited)+strlen(eqstr)< TTH_DLEN) {
@@ -18900,45 +18902,45 @@ YY_RULE_SETUP
 /* end of symbols */
 case 473:
 YY_RULE_SETUP
-#line 2710 "tth.lex"
+#line 2712 "tth.lex"
 /* Nothing needs doing */
 	YY_BREAK
 case 474:
 YY_RULE_SETUP
-#line 2711 "tth.lex"
+#line 2713 "tth.lex"
 TTH_SWAP("\\buildrel\\rightarrow\\over ");
 	YY_BREAK
 case 475:
 YY_RULE_SETUP
-#line 2712 "tth.lex"
+#line 2714 "tth.lex"
 TTH_SWAP("\\buildrel\\leftarrow\\over ");
 	YY_BREAK
 /* Above accents expressed with braces. Removed {WSP} 11 Apr */
 case 476:
 YY_RULE_SETUP
-#line 2715 "tth.lex"
+#line 2717 "tth.lex"
 { /* single character bar; convert to \sar */
   *(yytext+1)='s';
   TTH_SCAN_STRING(yytext);
  }
 	YY_BREAK
 case 477:
-#line 2720 "tth.lex"
-case 478:
-#line 2721 "tth.lex"
-case 479:
 #line 2722 "tth.lex"
-case 480:
+case 478:
 #line 2723 "tth.lex"
-case 481:
+case 479:
 #line 2724 "tth.lex"
-case 482:
+case 480:
 #line 2725 "tth.lex"
-case 483:
+case 481:
 #line 2726 "tth.lex"
+case 482:
+#line 2727 "tth.lex"
+case 483:
+#line 2728 "tth.lex"
 case 484:
 YY_RULE_SETUP
-#line 2726 "tth.lex"
+#line 2728 "tth.lex"
 {
   if(tth_debug&2) {
     fprintf(stderr,"Start Overaccent {, eqdepth=%d, eqclose=%d, tth_flev=%d, levdelim=%s.\n",eqdepth,eqclose,tth_flev,levdelim[eqclose]);
@@ -19029,17 +19031,17 @@ YY_RULE_SETUP
 /* Implementing sqrt as a command with optional argument.*/
 case 485:
 YY_RULE_SETUP
-#line 2814 "tth.lex"
+#line 2816 "tth.lex"
 TTH_SCAN_STRING("\\expandafter\\tthsqrtexp");
 	YY_BREAK
 case 486:
 YY_RULE_SETUP
-#line 2815 "tth.lex"
+#line 2817 "tth.lex"
 TTH_TEX_FN_OPT("\\tth_sqrt#tthdrop2",2,"");
 	YY_BREAK
 case 487:
 YY_RULE_SETUP
-#line 2816 "tth.lex"
+#line 2818 "tth.lex"
 {
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1)
     strcpy(scrstring,margs[jscratch]);
@@ -19118,7 +19120,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 488:
 YY_RULE_SETUP
-#line 2891 "tth.lex"
+#line 2893 "tth.lex"
 {
     TTH_CCPY(tth_root_index[tth_root_depth],eqstr);
     tth_root_len[tth_root_depth]=strlen(eqstr);
@@ -19128,32 +19130,32 @@ YY_RULE_SETUP
 	YY_BREAK
 case 489:
 YY_RULE_SETUP
-#line 2897 "tth.lex"
+#line 2899 "tth.lex"
 strcpy(levdelim[eqclose],"&#214;");
 	YY_BREAK
 /* Above accents etc without braces: embrace following token (and rescan). */
 case 490:
 /* rule 490 can match eol */
-#line 2902 "tth.lex"
+#line 2904 "tth.lex"
 case 491:
 /* rule 491 can match eol */
-#line 2903 "tth.lex"
+#line 2905 "tth.lex"
 case 492:
 /* rule 492 can match eol */
-#line 2904 "tth.lex"
+#line 2906 "tth.lex"
 case 493:
 /* rule 493 can match eol */
-#line 2905 "tth.lex"
+#line 2907 "tth.lex"
 case 494:
 /* rule 494 can match eol */
-#line 2906 "tth.lex"
+#line 2908 "tth.lex"
 case 495:
 /* rule 495 can match eol */
-#line 2907 "tth.lex"
+#line 2909 "tth.lex"
 case 496:
 /* rule 496 can match eol */
 YY_RULE_SETUP
-#line 2907 "tth.lex"
+#line 2909 "tth.lex"
 {  /* overline needs leading WSP */
   TTH_INC_MULTI; 
   strcpy(dupstore,yytext);
@@ -19166,7 +19168,7 @@ YY_RULE_SETUP
 case 497:
 /* rule 497 can match eol */
 YY_RULE_SETUP
-#line 2915 "tth.lex"
+#line 2917 "tth.lex"
 { /*This is default.*/
   TTH_INC_MULTI;
   if((tth_flev > 0 )){
@@ -19183,7 +19185,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 498:
 YY_RULE_SETUP
-#line 2928 "tth.lex"
+#line 2930 "tth.lex"
 { /* Fallback only */
   if((tth_flev > 0 ) && (eqaligncell)) {
     tth_enclose(TTH_EQ1,eqstr,TTH_EQ4,eqstore);
@@ -19195,7 +19197,7 @@ YY_RULE_SETUP
 case 499:
 /* rule 499 can match eol */
 YY_RULE_SETUP
-#line 2935 "tth.lex"
+#line 2937 "tth.lex"
 {
   TTH_INC_MULTI; 
   TTH_SCAN_STRING("\\left.\\tth_size2\\right");
@@ -19204,7 +19206,7 @@ YY_RULE_SETUP
 case 500:
 /* rule 500 can match eol */
 YY_RULE_SETUP
-#line 2939 "tth.lex"
+#line 2941 "tth.lex"
 {
   TTH_INC_MULTI; 
   TTH_SCAN_STRING("\\left.\\tth_size3\\right");
@@ -19212,41 +19214,41 @@ YY_RULE_SETUP
 	YY_BREAK
 case 501:
 YY_RULE_SETUP
-#line 2943 "tth.lex"
+#line 2945 "tth.lex"
 levhgt[eqclose]=2;
 	YY_BREAK
 case 502:
 YY_RULE_SETUP
-#line 2944 "tth.lex"
+#line 2946 "tth.lex"
 levhgt[eqclose]=3;
 	YY_BREAK
 case 503:
 /* rule 503 can match eol */
 YY_RULE_SETUP
-#line 2945 "tth.lex"
+#line 2947 "tth.lex"
 {
   TTH_INC_MULTI;yy_push_state(bigdel);strcpy(scratchstring,"{");}
 	YY_BREAK
 case 504:
 /* rule 504 can match eol */
 YY_RULE_SETUP
-#line 2947 "tth.lex"
+#line 2949 "tth.lex"
 {
   TTH_INC_MULTI;yy_push_state(bigdel);strcpy(scratchstring,"}");}
 	YY_BREAK
 case 505:
 YY_RULE_SETUP
-#line 2950 "tth.lex"
+#line 2952 "tth.lex"
 ;
 	YY_BREAK
 case 506:
 YY_RULE_SETUP
-#line 2951 "tth.lex"
+#line 2953 "tth.lex"
 ;
 	YY_BREAK
 case 507:
 YY_RULE_SETUP
-#line 2952 "tth.lex"
+#line 2954 "tth.lex"
 ;
 	YY_BREAK
 /* Textstyle html is so limited that it makes no sense to use it.
@@ -19265,24 +19267,24 @@ YY_RULE_SETUP
  */
 case 508:
 YY_RULE_SETUP
-#line 2967 "tth.lex"
+#line 2969 "tth.lex"
 
 	YY_BREAK
 case 509:
 YY_RULE_SETUP
-#line 2968 "tth.lex"
+#line 2970 "tth.lex"
 
 	YY_BREAK
 case 510:
 YY_RULE_SETUP
-#line 2969 "tth.lex"
+#line 2971 "tth.lex"
 
 	YY_BREAK
 /* Default equation actions. */
 /* Was single character. IE gave problems. */
 case 511:
 YY_RULE_SETUP
-#line 2973 "tth.lex"
+#line 2975 "tth.lex"
 {
     strcat(eqstr,tth_font_open[tth_push_depth]);
     strcat(eqstr,yytext);
@@ -19291,20 +19293,20 @@ YY_RULE_SETUP
 	YY_BREAK
 case 512:
 YY_RULE_SETUP
-#line 2979 "tth.lex"
+#line 2981 "tth.lex"
 TTH_MATHC(" ");
 	YY_BREAK
 case 513:
-#line 2981 "tth.lex"
-case 514:
-#line 2982 "tth.lex"
-case 515:
 #line 2983 "tth.lex"
-case 516:
+case 514:
 #line 2984 "tth.lex"
+case 515:
+#line 2985 "tth.lex"
+case 516:
+#line 2986 "tth.lex"
 case 517:
 YY_RULE_SETUP
-#line 2984 "tth.lex"
+#line 2986 "tth.lex"
 { 
   if(*(yytext) == '\\'){ chscratch=yytext+1;} else {chscratch=yytext;}
   if(*chscratch=='&')chscratch="&amp;";
@@ -19321,13 +19323,13 @@ YY_RULE_SETUP
 case 518:
 /* rule 518 can match eol */
 YY_RULE_SETUP
-#line 2996 "tth.lex"
+#line 2998 "tth.lex"
 TTH_INC_MULTI; TTH_SCAN_STRING(" = ");
 	YY_BREAK
 /**** tth pseudo-TeX ******/
 case 519:
 YY_RULE_SETUP
-#line 3001 "tth.lex"
+#line 3003 "tth.lex"
 {
   if(tth_debug&8) fprintf(stderr,"#tthbigsup, eqhgt=%d\n",eqhgt);
   strcat(eqstr,TTH_BR);
@@ -19349,7 +19351,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 520:
 YY_RULE_SETUP
-#line 3019 "tth.lex"
+#line 3021 "tth.lex"
 { /* Finish an eq group and attach to previous key */
   tth_prefix(eqstrs[eqdepth-1],eqstr,eqstore); /* prefix previous row.*/
   rmkey(eqstrs,&eqdepth);
@@ -19359,7 +19361,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 521:
 YY_RULE_SETUP
-#line 3025 "tth.lex"
+#line 3027 "tth.lex"
 {
   lefteq=1;
   colspan=3;
@@ -19369,19 +19371,19 @@ YY_RULE_SETUP
 case 522:
 /* rule 522 can match eol */
 YY_RULE_SETUP
-#line 3032 "tth.lex"
+#line 3034 "tth.lex"
 {
  TTH_INC_MULTI;
 } 
 	YY_BREAK
 case 523:
 YY_RULE_SETUP
-#line 3035 "tth.lex"
+#line 3037 "tth.lex"
 
 	YY_BREAK
 case 524:
 YY_RULE_SETUP
-#line 3036 "tth.lex"
+#line 3038 "tth.lex"
 { /* unenclosed subp. Embrace or expand it */
   *expchar=0;strcpy(exptex,yytext);yy_push_state(exptokarg);
   if(tth_debug&8)fprintf(stderr,"Expanding big subpscript\n");
@@ -19389,7 +19391,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 525:
 YY_RULE_SETUP
-#line 3040 "tth.lex"
+#line 3042 "tth.lex"
 {
   storetype=1;
   yy_push_state(dupgroup);
@@ -19398,7 +19400,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 526:
 YY_RULE_SETUP
-#line 3045 "tth.lex"
+#line 3047 "tth.lex"
 {
   storetype=2;
   yy_push_state(dupgroup);
@@ -19407,7 +19409,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 527:
 YY_RULE_SETUP
-#line 3050 "tth.lex"
+#line 3052 "tth.lex"
 {
   TTH_DO_MACRO
     else{
@@ -19417,7 +19419,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 528:
 YY_RULE_SETUP
-#line 3056 "tth.lex"
+#line 3058 "tth.lex"
 {
   if(tth_htmlstyle&4){
     TTH_OUTPUT("<span class=\"smaller\">");TTH_PRECLOSE("</span>");
@@ -19428,7 +19430,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 529:
 YY_RULE_SETUP
-#line 3063 "tth.lex"
+#line 3065 "tth.lex"
 { /* No more subp's */
   if(*yytext != '#') yyless(0);
   storetype=0;
@@ -19460,96 +19462,96 @@ YY_RULE_SETUP
 /* New big, left, right, delimiters section */
 case 530:
 YY_RULE_SETUP
-#line 3093 "tth.lex"
+#line 3095 "tth.lex"
 { 
   yy_pop_state();strcpy(levdelim[eqclose+1],"{");unput(*scratchstring);}
 	YY_BREAK
 case 531:
 YY_RULE_SETUP
-#line 3095 "tth.lex"
+#line 3097 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"}");unput(*scratchstring);}
 	YY_BREAK
 case 532:
 YY_RULE_SETUP
-#line 3097 "tth.lex"
+#line 3099 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"(");unput(*scratchstring);}
 	YY_BREAK
 case 533:
 YY_RULE_SETUP
-#line 3099 "tth.lex"
+#line 3101 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],")");unput(*scratchstring);}
 	YY_BREAK
 case 534:
 YY_RULE_SETUP
-#line 3101 "tth.lex"
+#line 3103 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"[");unput(*scratchstring);}
 	YY_BREAK
 case 535:
 YY_RULE_SETUP
-#line 3103 "tth.lex"
+#line 3105 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"]");unput(*scratchstring);}
 	YY_BREAK
 case 536:
 YY_RULE_SETUP
-#line 3105 "tth.lex"
+#line 3107 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#233;");unput(*scratchstring);}
 	YY_BREAK
 case 537:
 YY_RULE_SETUP
-#line 3107 "tth.lex"
+#line 3109 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#249;");unput(*scratchstring);}
 	YY_BREAK
 case 538:
 YY_RULE_SETUP
-#line 3109 "tth.lex"
+#line 3111 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#235;");unput(*scratchstring);}
 	YY_BREAK
 case 539:
 YY_RULE_SETUP
-#line 3111 "tth.lex"
+#line 3113 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#251;");unput(*scratchstring);}
 	YY_BREAK
 case 540:
 YY_RULE_SETUP
-#line 3113 "tth.lex"
+#line 3115 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#225;");unput(*scratchstring);}
 	YY_BREAK
 case 541:
 YY_RULE_SETUP
-#line 3115 "tth.lex"
+#line 3117 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"&#241;");unput(*scratchstring);}
 	YY_BREAK
 case 542:
 YY_RULE_SETUP
-#line 3117 "tth.lex"
+#line 3119 "tth.lex"
 {
   yy_pop_state();strcpy(levdelim[eqclose+1],"|");unput(*scratchstring);}
 	YY_BREAK
 case 543:
 YY_RULE_SETUP
-#line 3119 "tth.lex"
+#line 3121 "tth.lex"
 {
   yy_pop_state();*levdelim[eqclose+1]=*yytext;unput(*scratchstring);}
 	YY_BREAK
 case 544:
 YY_RULE_SETUP
-#line 3121 "tth.lex"
+#line 3123 "tth.lex"
 yy_pop_state();*levdelim[eqclose+1]=0;unput(*scratchstring);
 	YY_BREAK
 case 545:
 YY_RULE_SETUP
-#line 3122 "tth.lex"
+#line 3124 "tth.lex"
 { /* unknown bigdelimiter; make blank and then rescan. */
   yy_pop_state();yyless(0);
   TTH_SCAN_STRING(scratchstring);
@@ -19557,12 +19559,12 @@ YY_RULE_SETUP
 	YY_BREAK
 /* *************   LaTeX Math constructs.     ***********************/
 case 546:
-#line 3132 "tth.lex"
+#line 3134 "tth.lex"
 case 547:
-#line 3133 "tth.lex"
+#line 3135 "tth.lex"
 case 548:
 YY_RULE_SETUP
-#line 3133 "tth.lex"
+#line 3135 "tth.lex"
 {    /* Latex display equations */
   if(tth_debug&3)fprintf(stderr,"Latex display eqn %d\n",equatno);
   displaystyle=1;
@@ -19596,7 +19598,7 @@ YY_RULE_SETUP
 /* begin (inline) math moved after the close math */
 case 549:
 YY_RULE_SETUP
-#line 3163 "tth.lex"
+#line 3165 "tth.lex"
 { /* Assume this is NOT inside \math */
   if(strstr(yytext,"*") != NULL){
     eqalignlog=1; tth_multinum++; /* No row numbering. No end numbering */
@@ -19610,7 +19612,7 @@ YY_RULE_SETUP
 /* **********************   LateX Non Math  ********************************/
 case 550:
 YY_RULE_SETUP
-#line 3175 "tth.lex"
+#line 3177 "tth.lex"
 { /* Check for aux file. If present input. */
   tth_LaTeX=1;
   if(tth_splitfile)strcpy(filechar,"index.html"); /*sf*/
@@ -19657,7 +19659,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 551:
 YY_RULE_SETUP
-#line 3218 "tth.lex"
+#line 3220 "tth.lex"
 {/* Open index tid file for writing and start to do so. */
   if(strlen(tth_latex_file)){
     strcpy(scratchstring,tth_latex_file);strcat(scratchstring,".tid");
@@ -19678,7 +19680,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 552:
 YY_RULE_SETUP
-#line 3236 "tth.lex"
+#line 3238 "tth.lex"
 { /* Version to grab whole thing even special chars*/
   *dupstore=0;
   *argchar=0;
@@ -19691,7 +19693,7 @@ YY_RULE_SETUP
 case 553:
 /* rule 553 can match eol */
 YY_RULE_SETUP
-#line 3244 "tth.lex"
+#line 3246 "tth.lex"
 { /* \index action on group stored in dupstore. */
   yyless(0);
   yy_pop_state();
@@ -19751,8 +19753,8 @@ YY_RULE_SETUP
 		  scrstring,scratchstring,
 		   argchar,subsectno,tthindexrefno,
 		   argchar,page_compositor,subsectno);
-	fprintf(tth_fdout,"<a \nid=\"%s%s%d\"></a>"
-		,scratchstring,argchar,subsectno);
+	fprintf(tth_fdout,"<a \n id=\"%s%s%d%d\"></a>"
+		,scratchstring,argchar,subsectno,tthindexrefno);
       }else{ /* A |see case */
 	fprintf(tth_indexfile,
 		"\\indexentry{%s}{%s%s%d}\n",chscratch,
@@ -19766,7 +19768,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 554:
 YY_RULE_SETUP
-#line 3316 "tth.lex"
+#line 3318 "tth.lex"
 { /* Check for file. If present put title and open */
   if(tth_indexfile !=NULL){
     fprintf(stderr,"Closing index file and processing ...\n");
@@ -19806,7 +19808,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 555:
 YY_RULE_SETUP
-#line 3352 "tth.lex"
+#line 3354 "tth.lex"
 { /* Check for file. If present put title and open */
   TTH_CCPY(argchar,tth_latex_file);TTH_CCAT(argchar,".toc");
   if( (tth_inputfile=fopen(argchar,"r")) != NULL){
@@ -19822,7 +19824,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 556:
 YY_RULE_SETUP
-#line 3364 "tth.lex"
+#line 3366 "tth.lex"
 { /* Check for file. If present put title and open */
   TTH_CCPY(argchar,tth_latex_file);strcat(argchar,".lot");
   if( (tth_inputfile=fopen(argchar,"r")) != NULL){
@@ -19836,7 +19838,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 557:
 YY_RULE_SETUP
-#line 3374 "tth.lex"
+#line 3376 "tth.lex"
 { /* Check for file. If present put title and open */
   TTH_CCPY(argchar,tth_latex_file);strcat(argchar,".lof");
   if( (tth_inputfile=fopen(argchar,"r")) != NULL){
@@ -19851,7 +19853,7 @@ YY_RULE_SETUP
 case 558:
 /* rule 558 can match eol */
 YY_RULE_SETUP
-#line 3384 "tth.lex"
+#line 3386 "tth.lex"
 { /*Processing aux file*/
   TTH_INC_LINE
   if(strstr(yytext,"toc}{\\contentsline")==yytext+12){  /*sf*/
@@ -19872,7 +19874,7 @@ YY_RULE_SETUP
 case 559:
 /* rule 559 can match eol */
 YY_RULE_SETUP
-#line 3400 "tth.lex"
+#line 3402 "tth.lex"
 {
   horizmode=1;
   *scrstring=0;
@@ -19928,7 +19930,7 @@ YY_RULE_SETUP
 case 560:
 /* rule 560 can match eol */
 YY_RULE_SETUP
-#line 3451 "tth.lex"
+#line 3453 "tth.lex"
 {
   TTH_INC_MULTI;
   js2=strcspn(yytext,"{");
@@ -19996,12 +19998,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 561:
 YY_RULE_SETUP
-#line 3516 "tth.lex"
+#line 3518 "tth.lex"
 TTH_TEX_FN("\\tth_thebibliography#tthdrop1",1);
 	YY_BREAK
 case 562:
 YY_RULE_SETUP
-#line 3517 "tth.lex"
+#line 3519 "tth.lex"
 {
   if(lbook)  {TTH_SCAN_STRING("\\special{html:<h2>}\\bibname\\special{html:</h2>\n}\\begin{description}");}
   else {TTH_SCAN_STRING("\\special{html:<h2>}\\refname\\special{html:</h2>\n}\\begin{description}");}
@@ -20016,13 +20018,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 563:
 YY_RULE_SETUP
-#line 3529 "tth.lex"
+#line 3531 "tth.lex"
 TTH_TEX_FN_OPT("\\tthbibitem{#2}#tthdrop2",2,"");
 	YY_BREAK
 case 564:
 /* rule 564 can match eol */
 YY_RULE_SETUP
-#line 3530 "tth.lex"
+#line 3532 "tth.lex"
 {
   TTH_INC_MULTI;
   TTH_OUTPUT(closing);strcpy(closing,"</dd>\n"); /*27 Apr 2001 */
@@ -20058,7 +20060,7 @@ YY_RULE_SETUP
 case 565:
 /* rule 565 can match eol */
 YY_RULE_SETUP
-#line 3561 "tth.lex"
+#line 3563 "tth.lex"
 { /* Input the bbl file. */
   TTH_CCPY(argchar,tth_latex_file);strcat(argchar,".bbl");
   if( (tth_inputfile=fopen(argchar,"r")) != NULL){
@@ -20102,7 +20104,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 566:
 YY_RULE_SETUP
-#line 3602 "tth.lex"
+#line 3604 "tth.lex"
 {
   chapno=0;sectno=0;appendix=1;
   if(lbook) strcpy(scratchstring,
@@ -20114,14 +20116,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 567:
 YY_RULE_SETUP
-#line 3610 "tth.lex"
+#line 3612 "tth.lex"
 {  
   fprintf(tth_fdout,"\n<h1>"); yy_push_state(tokenarg); TTH_CCPY(argchar,"</h1>");
 }
 	YY_BREAK
 case 568:
 YY_RULE_SETUP
-#line 3613 "tth.lex"
+#line 3615 "tth.lex"
 {
   sprintf(scratchstring,"%s\\tthenclose{\\special{html:<br /><h1>}%s{ %s}   \\special{html:<br />}}{\\special{html:</h1><br />}} ",
 	  "\\stepcounter{part}",
@@ -20131,13 +20133,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 569:
 YY_RULE_SETUP
-#line 3619 "tth.lex"
+#line 3621 "tth.lex"
 {
   fprintf(tth_fdout,"\n<h1>"); yy_push_state(tokenarg); TTH_CCPY(argchar,"</h1>");}
 	YY_BREAK
 case 570:
 YY_RULE_SETUP
-#line 3621 "tth.lex"
+#line 3623 "tth.lex"
 {
   figureno=0;tableno=0;
   sprintf(labelchar,"%d",chapno+1);
@@ -20151,12 +20153,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 571:
 YY_RULE_SETUP
-#line 3631 "tth.lex"
+#line 3633 "tth.lex"
 if(tth_splitfile)  strcpy(filechar,filenext); /*sf*/
 	YY_BREAK
 case 572:
 YY_RULE_SETUP
-#line 3632 "tth.lex"
+#line 3634 "tth.lex"
 {/*sf*/
   fprintf(tth_fdout,TTH_MIME_DIVIDE,filenext);/*sf*/
   fprintf(tth_fdout,TTH_DOCTYPE); /*sf*/
@@ -20171,17 +20173,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 573:
 YY_RULE_SETUP
-#line 3643 "tth.lex"
+#line 3645 "tth.lex"
 fprintf(tth_fdout,"%s",filenext); /*sf*/
 	YY_BREAK
 case 574:
 YY_RULE_SETUP
-#line 3644 "tth.lex"
+#line 3646 "tth.lex"
 fprintf(tth_fdout,"%s",filechar); /*sf*/
 	YY_BREAK
 case 575:
 YY_RULE_SETUP
-#line 3645 "tth.lex"
+#line 3647 "tth.lex"
 {
   if(appendix) {TTH_CCPY(argchar,"\\appendixname");}
   else TTH_CCPY(argchar,"\\chaptername");
@@ -20194,13 +20196,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 576:
 YY_RULE_SETUP
-#line 3654 "tth.lex"
+#line 3656 "tth.lex"
 {   
   fprintf(tth_fdout,"\n<h2>"); yy_push_state(tokenarg); TTH_CCPY(argchar,"</h2>");}
 	YY_BREAK
 case 577:
 YY_RULE_SETUP
-#line 3656 "tth.lex"
+#line 3658 "tth.lex"
 {
   TTH_SCAN_STRING("\\tthsectcomplete");
   if(lbook) {
@@ -20218,7 +20220,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 578:
 YY_RULE_SETUP
-#line 3670 "tth.lex"
+#line 3672 "tth.lex"
 {
   if(secnumdepth > 0){
     /* the following needs the space at the end for tex compatibility */
@@ -20235,13 +20237,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 579:
 YY_RULE_SETUP
-#line 3683 "tth.lex"
+#line 3685 "tth.lex"
 {   
   fprintf(tth_fdout,"\n<h3>"); yy_push_state(tokenarg); TTH_CCPY(argchar,"</h3>");}
 	YY_BREAK
 case 580:
 YY_RULE_SETUP
-#line 3685 "tth.lex"
+#line 3687 "tth.lex"
 {
   { 
     if(lbook) {
@@ -20264,13 +20266,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 581:
 YY_RULE_SETUP
-#line 3704 "tth.lex"
+#line 3706 "tth.lex"
 {   
   fprintf(tth_fdout,"\n<h4>"); yy_push_state(tokenarg); TTH_CCPY(argchar,"</h4>");}
 	YY_BREAK
 case 582:
 YY_RULE_SETUP
-#line 3706 "tth.lex"
+#line 3708 "tth.lex"
 { 
   {
     if(lbook) {
@@ -20296,7 +20298,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 583:
 YY_RULE_SETUP
-#line 3728 "tth.lex"
+#line 3730 "tth.lex"
 {
   if(secnumdepth > 3){
     TTH_TEX_FN("\\par\\stepcounter{paragraph}{\\bf\\theparagraph\
@@ -20309,7 +20311,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 584:
 YY_RULE_SETUP
-#line 3737 "tth.lex"
+#line 3739 "tth.lex"
 {
   if(secnumdepth > 4){
     TTH_TEX_FN("\\stepcounter{subparagraph}{\\special{html:<br />}\
@@ -20324,7 +20326,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 585:
 YY_RULE_SETUP
-#line 3749 "tth.lex"
+#line 3751 "tth.lex"
 {
   if(tth_debug&256)fprintf(stderr,"Caption in environment:%s\n",environment);
   if(!strcmp(environment,"figure")){
@@ -20343,7 +20345,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 586:
 YY_RULE_SETUP
-#line 3764 "tth.lex"
+#line 3766 "tth.lex"
 {
   if(horizmode) horizmode=1;
   jscratch=indexkey("#1",margkeys,&margmax);
@@ -20389,7 +20391,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 587:
 YY_RULE_SETUP
-#line 3806 "tth.lex"
+#line 3808 "tth.lex"
 { /* Called only by \label latex builtin. */
   if(horizmode) horizmode=1;
   jscratch=indexkey("#1",margkeys,&margmax);
@@ -20423,10 +20425,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 588:
-#line 3838 "tth.lex"
+#line 3840 "tth.lex"
 case 589:
 YY_RULE_SETUP
-#line 3838 "tth.lex"
+#line 3840 "tth.lex"
 {
   if(horizmode) horizmode=1;
   jscratch=indexkey("#1",margkeys,&margmax);
@@ -20460,12 +20462,12 @@ YY_RULE_SETUP
 case 590:
 /* rule 590 can match eol */
 YY_RULE_SETUP
-#line 3868 "tth.lex"
+#line 3870 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 591:
 YY_RULE_SETUP
-#line 3869 "tth.lex"
+#line 3871 "tth.lex"
 {
   /* These are purely to silence warnings. They are non-functional*/
   PUSHEDINTS[0][0]=0;
@@ -20481,7 +20483,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 592:
 YY_RULE_SETUP
-#line 3881 "tth.lex"
+#line 3883 "tth.lex"
 {
   yy_pop_state();
   yyless(0);
@@ -20497,7 +20499,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 593:
 YY_RULE_SETUP
-#line 3894 "tth.lex"
+#line 3896 "tth.lex"
 {
   countstart=ncounters;
   if(tth_debug&512) fprintf(stderr,"Countstart= %d\n",countstart);
@@ -20506,7 +20508,7 @@ YY_RULE_SETUP
 case 594:
 /* rule 594 can match eol */
 YY_RULE_SETUP
-#line 3899 "tth.lex"
+#line 3901 "tth.lex"
 {
   TTH_INC_MULTI;
   if(indexkey("\\label",keys,&nkeys) == -1){ /* Only if not already done */
@@ -20539,7 +20541,7 @@ YY_RULE_SETUP
 case 595:
 /* rule 595 can match eol */
 YY_RULE_SETUP
-#line 3928 "tth.lex"
+#line 3930 "tth.lex"
 {
   TTH_INC_MULTI;
   if(strstr(yytext,"numbers")){TTH_SCAN_STRING("\\NAT@numberstrue ");}
@@ -20553,56 +20555,56 @@ YY_RULE_SETUP
 	YY_BREAK
 case 596:
 YY_RULE_SETUP
-#line 3938 "tth.lex"
+#line 3940 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 /* Font faces and styles etc.*/
 case 597:
-#line 3942 "tth.lex"
+#line 3944 "tth.lex"
 case 598:
-YY_RULE_SETUP
-#line 3942 "tth.lex"
-TTH_SWAP("\\rm ");
-	YY_BREAK
-case 599:
-YY_RULE_SETUP
-#line 3943 "tth.lex"
-TTH_SWAP("\\bf ");
-	YY_BREAK
-case 600:
 YY_RULE_SETUP
 #line 3944 "tth.lex"
 TTH_SWAP("\\rm ");
 	YY_BREAK
-case 601:
+case 599:
 YY_RULE_SETUP
 #line 3945 "tth.lex"
+TTH_SWAP("\\bf ");
+	YY_BREAK
+case 600:
+YY_RULE_SETUP
+#line 3946 "tth.lex"
+TTH_SWAP("\\rm ");
+	YY_BREAK
+case 601:
+YY_RULE_SETUP
+#line 3947 "tth.lex"
 TTH_SWAP("\\it ");
 	YY_BREAK
 case 602:
 YY_RULE_SETUP
-#line 3946 "tth.lex"
+#line 3948 "tth.lex"
 TTH_SWAP("\\it ");
 	YY_BREAK
 case 603:
 YY_RULE_SETUP
-#line 3947 "tth.lex"
+#line 3949 "tth.lex"
 TTH_SWAP("\\tt ");
 	YY_BREAK
 case 604:
 YY_RULE_SETUP
-#line 3948 "tth.lex"
+#line 3950 "tth.lex"
 TTH_SWAP("\\sffamily ");
 	YY_BREAK
 case 605:
 YY_RULE_SETUP
-#line 3949 "tth.lex"
+#line 3951 "tth.lex"
 TTH_SWAP("\\scshape ");
 	YY_BREAK
 /*   Now using the halign brace closure */
 case 606:
 YY_RULE_SETUP
-#line 3951 "tth.lex"
+#line 3953 "tth.lex"
 {
   TTH_OUTPUT(TTH_SMALLCAPS_FONT1);
   for(jscratch=0;jscratch<strlen(yytext);jscratch++) {
@@ -20613,29 +20615,29 @@ YY_RULE_SETUP
 	YY_BREAK
 case 607:
 YY_RULE_SETUP
-#line 3958 "tth.lex"
+#line 3960 "tth.lex"
 TTH_OUTPUT(yytext);horizmode=1; /* Trying to fix in equations */
 	YY_BREAK
 case 608:
 YY_RULE_SETUP
-#line 3961 "tth.lex"
+#line 3963 "tth.lex"
 TTH_OUTPUT(TTH_EM1);TTH_PRECLOSE(TTH_EM2);
 	YY_BREAK
 case 609:
-#line 3963 "tth.lex"
+#line 3965 "tth.lex"
 case 610:
 YY_RULE_SETUP
-#line 3963 "tth.lex"
+#line 3965 "tth.lex"
 TTH_SWAP("\\em ");
 	YY_BREAK
 case 611:
 YY_RULE_SETUP
-#line 3964 "tth.lex"
+#line 3966 "tth.lex"
 TTH_SCAN_STRING("{\\em ");
 	YY_BREAK
 case 612:
 YY_RULE_SETUP
-#line 3965 "tth.lex"
+#line 3967 "tth.lex"
 {
   if(horizmode) horizmode=1;
   fprintf(tth_fdout,"\n<pre>"); yy_push_state(verbatim);
@@ -20643,25 +20645,25 @@ YY_RULE_SETUP
 	YY_BREAK
 case 613:
 YY_RULE_SETUP
-#line 3969 "tth.lex"
+#line 3971 "tth.lex"
 {
   fprintf(tth_fdout,"\n<div style=\"text-align:center\">");  TTH_PUSH_CLOSING;  TTH_CCPY(closing,"</div>");}
 	YY_BREAK
 case 614:
 YY_RULE_SETUP
-#line 3971 "tth.lex"
+#line 3973 "tth.lex"
 {
   if(horizmode) horizmode=1;
   fprintf(tth_fdout,"\n<div align=\"right\">");TTH_PUSH_CLOSING;
   TTH_CCPY(closing,"</div>");}
 	YY_BREAK
 case 615:
-#line 3976 "tth.lex"
+#line 3978 "tth.lex"
 case 616:
-#line 3977 "tth.lex"
+#line 3979 "tth.lex"
 case 617:
 YY_RULE_SETUP
-#line 3977 "tth.lex"
+#line 3979 "tth.lex"
 {
   if(horizmode) horizmode=1;
   fprintf(tth_fdout,"\n<blockquote><div>");
@@ -20669,7 +20671,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 618:
 YY_RULE_SETUP
-#line 3981 "tth.lex"
+#line 3983 "tth.lex"
 {
   if(horizmode) horizmode=1;
   TTH_SCAN_STRING("\\beginsection{\\abstractname}\\par");
@@ -20678,12 +20680,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 619:
 YY_RULE_SETUP
-#line 3986 "tth.lex"
+#line 3988 "tth.lex"
 TTH_SCAN_STRING("\\egroup\\par");
 	YY_BREAK
 case 620:
 YY_RULE_SETUP
-#line 3988 "tth.lex"
+#line 3990 "tth.lex"
 {
   horizmode=0;
   fprintf(tth_fdout,"\n<ul>");yy_push_state(Litemize);
@@ -20694,7 +20696,7 @@ YY_RULE_SETUP
 case 621:
 /* rule 621 can match eol */
 YY_RULE_SETUP
-#line 3994 "tth.lex"
+#line 3996 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_pop_state();
@@ -20707,7 +20709,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 622:
 YY_RULE_SETUP
-#line 4004 "tth.lex"
+#line 4006 "tth.lex"
 {
   horizmode=0;
   fprintf(tth_fdout,"\n<ol type=\"%c\">",
@@ -20721,7 +20723,7 @@ YY_RULE_SETUP
 case 623:
 /* rule 623 can match eol */
 YY_RULE_SETUP
-#line 4013 "tth.lex"
+#line 4015 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_pop_state();
@@ -20735,7 +20737,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 624:
 YY_RULE_SETUP
-#line 4023 "tth.lex"
+#line 4025 "tth.lex"
 {    /* list like description */
   horizmode=0;
   fprintf(tth_fdout,"\n<dl>\n");yy_push_state(Ldescription);
@@ -20749,7 +20751,7 @@ YY_RULE_SETUP
 /* Multiple column index. */
 case 625:
 YY_RULE_SETUP
-#line 4033 "tth.lex"
+#line 4035 "tth.lex"
 {
   if(tth_debug&3)fprintf(stderr,"Starting the index ");
   horizmode=0;
@@ -20765,7 +20767,7 @@ YY_RULE_SETUP
 case 626:
 /* rule 626 can match eol */
 YY_RULE_SETUP
-#line 4045 "tth.lex"
+#line 4047 "tth.lex"
 {
   /* fprintf(stderr,"indexspace\n"); */
   TTH_INC_MULTI;
@@ -20786,7 +20788,7 @@ YY_RULE_SETUP
 case 627:
 /* rule 627 can match eol */
 YY_RULE_SETUP
-#line 4062 "tth.lex"
+#line 4064 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_pop_state();
@@ -20798,7 +20800,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 628:
 YY_RULE_SETUP
-#line 4071 "tth.lex"
+#line 4073 "tth.lex"
 {
   /*  if(horizmode) horizmode=1; */
   horizmode=0;
@@ -20809,11 +20811,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 629:
 /* rule 629 can match eol */
-#line 4079 "tth.lex"
+#line 4081 "tth.lex"
 case 630:
 /* rule 630 can match eol */
 YY_RULE_SETUP
-#line 4079 "tth.lex"
+#line 4081 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_pop_state();
@@ -20826,7 +20828,7 @@ YY_RULE_SETUP
 case 631:
 /* rule 631 can match eol */
 YY_RULE_SETUP
-#line 4087 "tth.lex"
+#line 4089 "tth.lex"
 {
   TTH_INC_MULTI;
   if(horizmode) horizmode=1;
@@ -20841,7 +20843,7 @@ YY_RULE_SETUP
 case 632:
 /* rule 632 can match eol */
 YY_RULE_SETUP
-#line 4097 "tth.lex"
+#line 4099 "tth.lex"
 {
   TTH_INC_MULTI;
   if(horizmode) horizmode=1;
@@ -20854,10 +20856,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 633:
-#line 4108 "tth.lex"
+#line 4110 "tth.lex"
 case 634:
 YY_RULE_SETUP
-#line 4108 "tth.lex"
+#line 4110 "tth.lex"
 {   /* Special case. Remove environment label. */
   TTH_TEXCLOSE else{
   TTH_CLOSEGROUP;TTH_POP_CLOSING;
@@ -20867,12 +20869,12 @@ YY_RULE_SETUP
 case 635:
 /* rule 635 can match eol */
 YY_RULE_SETUP
-#line 4114 "tth.lex"
+#line 4116 "tth.lex"
 strcpy(unitlength,yytext);
 	YY_BREAK
 case 636:
 YY_RULE_SETUP
-#line 4115 "tth.lex"
+#line 4117 "tth.lex"
 {
   if(tth_autopic){
     picno++;
@@ -20906,12 +20908,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 637:
 YY_RULE_SETUP
-#line 4145 "tth.lex"
+#line 4147 "tth.lex"
 jscratch++;fprintf(tth_picfile,"%s",yytext);    
 	YY_BREAK
 case 638:
 YY_RULE_SETUP
-#line 4146 "tth.lex"
+#line 4148 "tth.lex"
 {
   if(jscratch) {jscratch--; fprintf(tth_picfile,"%s",yytext);}    
   else{
@@ -20931,13 +20933,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 639:
 YY_RULE_SETUP
-#line 4162 "tth.lex"
+#line 4164 "tth.lex"
 
 	YY_BREAK
 case 640:
 /* rule 640 can match eol */
 YY_RULE_SETUP
-#line 4163 "tth.lex"
+#line 4165 "tth.lex"
 {
   if(strcspn(yytext,"\n")==0) TTH_INC_LINE;
   fprintf(tth_picfile,"%s",yytext);
@@ -20945,7 +20947,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 641:
 YY_RULE_SETUP
-#line 4167 "tth.lex"
+#line 4169 "tth.lex"
 {
   yy_push_state(discardgroup);
   if(tth_debug&32)fprintf(stderr,"Discarding unsupported construct:%s\n",yytext);
@@ -20953,7 +20955,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 642:
 YY_RULE_SETUP
-#line 4171 "tth.lex"
+#line 4173 "tth.lex"
 {
   yy_pop_state();
   if(tth_debug&32)fprintf(stderr,"Ending discarding construct:%s\n",yytext);
@@ -20961,26 +20963,26 @@ YY_RULE_SETUP
 	YY_BREAK
 case 643:
 YY_RULE_SETUP
-#line 4175 "tth.lex"
+#line 4177 "tth.lex"
 
 	YY_BREAK
 /***********************************************************************/
 /* Latex tabular and haligns */
 case 644:
 YY_RULE_SETUP
-#line 4179 "tth.lex"
+#line 4181 "tth.lex"
 TTH_TEX_FN("\\begin{tabular}#tthdrop1",1);
 	YY_BREAK
 case 645:
 YY_RULE_SETUP
-#line 4180 "tth.lex"
+#line 4182 "tth.lex"
 {
   TTH_TEX_FN_OPT("\\tth_tabular#tthdrop2",2,"");
 }
 	YY_BREAK
 case 646:
 YY_RULE_SETUP
-#line 4183 "tth.lex"
+#line 4185 "tth.lex"
 {
   TTH_HAL_PUSH;
   *halstring=0;
@@ -21000,22 +21002,22 @@ YY_RULE_SETUP
 case 647:
 /* rule 647 can match eol */
 YY_RULE_SETUP
-#line 4198 "tth.lex"
+#line 4200 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 648:
 YY_RULE_SETUP
-#line 4199 "tth.lex"
+#line 4201 "tth.lex"
 /*remove spaces*/
 	YY_BREAK
 case 649:
 YY_RULE_SETUP
-#line 4200 "tth.lex"
+#line 4202 "tth.lex"
 TTH_CCAT(halstring,yytext);
 	YY_BREAK
 case 650:
 YY_RULE_SETUP
-#line 4201 "tth.lex"
+#line 4203 "tth.lex"
 TTH_CCAT(halstring,yytext);ncols++;
 	YY_BREAK
 /*
@@ -21026,12 +21028,12 @@ TTH_CCAT(halstring,yytext);ncols++;
 }*/
 case 651:
 YY_RULE_SETUP
-#line 4208 "tth.lex"
+#line 4210 "tth.lex"
 {  TTH_TEX_FN("\\tth_preat#tthdrop1",1); }
 	YY_BREAK
 case 652:
 YY_RULE_SETUP
-#line 4209 "tth.lex"
+#line 4211 "tth.lex"
 {
   yy_pop_state();
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
@@ -21045,12 +21047,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 653:
 YY_RULE_SETUP
-#line 4219 "tth.lex"
+#line 4221 "tth.lex"
 { TTH_TEX_FN("\\tth_presp#tthdrop1",1);ncols++; }
 	YY_BREAK
 case 654:
 YY_RULE_SETUP
-#line 4220 "tth.lex"
+#line 4222 "tth.lex"
 {
   yy_pop_state();
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
@@ -21065,7 +21067,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 655:
 YY_RULE_SETUP
-#line 4231 "tth.lex"
+#line 4233 "tth.lex"
 {
   /*  sprintf(scratchstring,"&{&p{%d}&}&",thesize/SCALEDPERPIXEL);*/
   sprintf(scratchstring,"p{%d}",thesize/SCALEDPERPIXEL);
@@ -21076,12 +21078,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 656:
 YY_RULE_SETUP
-#line 4238 "tth.lex"
+#line 4240 "tth.lex"
 { TTH_TEX_FN("\\tth_tabstar#tthdrop2",2); }
 	YY_BREAK
 case 657:
 YY_RULE_SETUP
-#line 4239 "tth.lex"
+#line 4241 "tth.lex"
 {
   yy_pop_state();
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
@@ -21100,12 +21102,12 @@ YY_RULE_SETUP
 case 658:
 /* rule 658 can match eol */
 YY_RULE_SETUP
-#line 4253 "tth.lex"
+#line 4255 "tth.lex"
 if(strcspn(yytext,"\n")==0) TTH_INC_LINE;/* Do nothing if we don't recognize */ 
 	YY_BREAK
 case 659:
 YY_RULE_SETUP
-#line 4254 "tth.lex"
+#line 4256 "tth.lex"
 {
   yy_pop_state();
   TTH_PUSH_CLOSING;
@@ -21140,7 +21142,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 660:
 YY_RULE_SETUP
-#line 4286 "tth.lex"
+#line 4288 "tth.lex"
 { /* cell boundary. Scan @strings if any */
   if(tth_debug&32)fprintf(stderr,"|");
   jstal=-1;
@@ -21158,7 +21160,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 661:
 YY_RULE_SETUP
-#line 4300 "tth.lex"
+#line 4302 "tth.lex"
 {
   /*  if(tth_debug&32) fprintf(stderr,"tth_@, %d\n",margmax);*/
   TTH_TEX_FN("\\tth_atstring#tthdrop1",1);
@@ -21166,7 +21168,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 662:
 YY_RULE_SETUP
-#line 4304 "tth.lex"
+#line 4306 "tth.lex"
 {
   yy_pop_state();
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
@@ -21186,7 +21188,7 @@ YY_RULE_SETUP
 case 663:
 /* rule 663 can match eol */
 YY_RULE_SETUP
-#line 4320 "tth.lex"
+#line 4322 "tth.lex"
 {
   if(jshal==1||jshal==-1){yyless(0);} 
   if(jstal==-1)jstal=0;
@@ -21194,7 +21196,7 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case YY_STATE_EOF(talign):
-#line 4325 "tth.lex"
+#line 4327 "tth.lex"
 {  /* Reset halbuff to start. Gives matrix underflows.
     yy_delete_buffer(YY_CURRENT_BUFFER);
     if(tth_debug&32)fprintf(stderr,"\nTemplate end rescan:%s> \n",halstring);
@@ -21205,12 +21207,12 @@ case YY_STATE_EOF(talign):
 	YY_BREAK
 case 664:
 YY_RULE_SETUP
-#line 4332 "tth.lex"
+#line 4334 "tth.lex"
 yy_push_state(tempamp);
 	YY_BREAK
 case 665:
 YY_RULE_SETUP
-#line 4333 "tth.lex"
+#line 4335 "tth.lex"
 {
   yy_pop_state();
   /*  if(tth_debug&32)fprintf(stderr,"%dprecell=%s\n",jshal,precell);*/
@@ -21219,15 +21221,15 @@ YY_RULE_SETUP
 	YY_BREAK
 case 666:
 YY_RULE_SETUP
-#line 4338 "tth.lex"
+#line 4340 "tth.lex"
 {TTH_CCAT(precell,yytext);}
 	YY_BREAK
 case 667:
-#line 4340 "tth.lex"
+#line 4342 "tth.lex"
 case 668:
 /* rule 668 can match eol */
 YY_RULE_SETUP
-#line 4340 "tth.lex"
+#line 4342 "tth.lex"
 {
   if(strcspn(yytext,"\n")==0) TTH_INC_LINE;
   if(jshal<1){TTH_CCAT(precell,yytext);}
@@ -21235,46 +21237,46 @@ YY_RULE_SETUP
 	YY_BREAK
 case 669:
 YY_RULE_SETUP
-#line 4344 "tth.lex"
+#line 4346 "tth.lex"
 fprintf(stderr,"Unknown tabular format: %s\n",yytext);TTH_HALACT;
 	YY_BREAK
 case 670:
 YY_RULE_SETUP
-#line 4346 "tth.lex"
+#line 4348 "tth.lex"
 TTH_SCAN_STRING("\\par");
 	YY_BREAK
 case 671:
 YY_RULE_SETUP
-#line 4347 "tth.lex"
+#line 4349 "tth.lex"
 {
   fprintf(tth_fdout,"\n</td><td%s>",valignstring);
 }
 	YY_BREAK
 case 672:
 YY_RULE_SETUP
-#line 4350 "tth.lex"
+#line 4352 "tth.lex"
 {
   yy_pop_state();
 }
 	YY_BREAK
 case 673:
 YY_RULE_SETUP
-#line 4354 "tth.lex"
+#line 4356 "tth.lex"
 {
   if(*halstring) {yy_push_state(hamper); 
   }else{fprintf(tth_fdout,"</td><td width=\"%d\">\n",tabwidth);}/* settabs */
 }
 	YY_BREAK
 case 674:
-#line 4359 "tth.lex"
-case 675:
-#line 4360 "tth.lex"
-case 676:
 #line 4361 "tth.lex"
+case 675:
+#line 4362 "tth.lex"
+case 676:
+#line 4363 "tth.lex"
 case 677:
 /* rule 677 can match eol */
 YY_RULE_SETUP
-#line 4361 "tth.lex"
+#line 4363 "tth.lex"
 {
   TTH_INC_MULTI;
   if(*halstring){ /* halign and tabular */
@@ -21313,17 +21315,17 @@ YY_RULE_SETUP
 case 678:
 /* rule 678 can match eol */
 YY_RULE_SETUP
-#line 4395 "tth.lex"
+#line 4397 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 679:
 YY_RULE_SETUP
-#line 4396 "tth.lex"
+#line 4398 "tth.lex"
 
 	YY_BREAK
 case 680:
 YY_RULE_SETUP
-#line 4397 "tth.lex"
+#line 4399 "tth.lex"
 {
   if(tth_debug&32) fprintf(stderr,"\nInner Multicolumn(%d%d)",jshal,jstal);
   if(jstal==0){
@@ -21341,12 +21343,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 681:
 YY_RULE_SETUP
-#line 4411 "tth.lex"
+#line 4413 "tth.lex"
 TTH_SCAN_STRING("\\multispan1");
 	YY_BREAK
 case 682:
 YY_RULE_SETUP
-#line 4412 "tth.lex"
+#line 4414 "tth.lex"
 {
   if(tth_debug&32) fprintf(stderr,"Inner Multispan(%d%d)",jshal,jstal);
   if(jstal==0){
@@ -21365,7 +21367,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 683:
 YY_RULE_SETUP
-#line 4427 "tth.lex"
+#line 4429 "tth.lex"
 { /* expand first */
   TTH_DO_MACRO
   else{ 
@@ -21378,7 +21380,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 684:
 YY_RULE_SETUP
-#line 4436 "tth.lex"
+#line 4438 "tth.lex"
 {
   yyless(0);
   strcpy(tdalign,TTH_CELL_TAB);  /* Save the cell closing.*/
@@ -21389,34 +21391,34 @@ YY_RULE_SETUP
 	YY_BREAK
 case 685:
 YY_RULE_SETUP
-#line 4443 "tth.lex"
+#line 4445 "tth.lex"
 
 	YY_BREAK
 case 686:
 /* rule 686 can match eol */
 YY_RULE_SETUP
-#line 4444 "tth.lex"
+#line 4446 "tth.lex"
 TTH_INC_MULTI;TTH_OUTPUT(TTH_TRTD);
 	YY_BREAK
 case 687:
 YY_RULE_SETUP
-#line 4445 "tth.lex"
+#line 4447 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 case 688:
 YY_RULE_SETUP
-#line 4446 "tth.lex"
+#line 4448 "tth.lex"
 
 	YY_BREAK
 case 689:
 /* rule 689 can match eol */
 YY_RULE_SETUP
-#line 4447 "tth.lex"
+#line 4449 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 690:
 YY_RULE_SETUP
-#line 4449 "tth.lex"
+#line 4451 "tth.lex"
 {
   if(tth_debug&32) fprintf(stderr,"Multicolumn at start:");
   TTH_OUTPUT(TTH_TRO);
@@ -21426,7 +21428,7 @@ YY_RULE_SETUP
 /* Add an open brace for a starting multicol */
 case 691:
 YY_RULE_SETUP
-#line 4455 "tth.lex"
+#line 4457 "tth.lex"
 {
   /*TTH_SCAN_STRING("{");
     if(tth_debug&32){fprintf(stderr,"{");}*/
@@ -21435,7 +21437,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 692:
 YY_RULE_SETUP
-#line 4460 "tth.lex"
+#line 4462 "tth.lex"
 {
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
     sscanf(margs[jscratch],"%d",&jshal);
@@ -21457,7 +21459,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 693:
 YY_RULE_SETUP
-#line 4478 "tth.lex"
+#line 4480 "tth.lex"
 {
   TTH_TEXCLOSE else{
   if(tth_debug&32) fprintf(stderr,"Ending tabular\n");
@@ -21483,7 +21485,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 694:
 YY_RULE_SETUP
-#line 4500 "tth.lex"
+#line 4502 "tth.lex"
 {
   yy_pop_state(); /* out of hendline */
   TTH_TEXCLOSE else{
@@ -21501,7 +21503,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 695:
 YY_RULE_SETUP
-#line 4514 "tth.lex"
+#line 4516 "tth.lex"
 {
   yyless(0); TTH_OUTPUT(TTH_TRO);
   yy_pop_state();
@@ -21511,7 +21513,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 696:
 YY_RULE_SETUP
-#line 4521 "tth.lex"
+#line 4523 "tth.lex"
 {/*attempt to fix*/
   if(tth_debug&33) fprintf(stderr,
 	"Noalign in hendline. eqdepth=%d, ncols=%d.\n",eqdepth,ncols);
@@ -21521,12 +21523,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 697:
 YY_RULE_SETUP
-#line 4528 "tth.lex"
+#line 4530 "tth.lex"
 TTH_SCAN_STRING("\\multispan1");
 	YY_BREAK
 case 698:
 YY_RULE_SETUP
-#line 4529 "tth.lex"
+#line 4531 "tth.lex"
 {
   yy_pop_state();
   if(tth_debug&32) fprintf(stderr,"Line Start Multispan\n");
@@ -21536,7 +21538,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 699:
 YY_RULE_SETUP
-#line 4535 "tth.lex"
+#line 4537 "tth.lex"
 {
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1)
     sscanf(margs[jscratch],"%d",&jshal);
@@ -21551,7 +21553,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 700:
 YY_RULE_SETUP
-#line 4546 "tth.lex"
+#line 4548 "tth.lex"
 { /* expand first */
   TTH_DO_MACRO
   else{
@@ -21564,80 +21566,80 @@ YY_RULE_SETUP
 	YY_BREAK
 case 701:
 YY_RULE_SETUP
-#line 4555 "tth.lex"
+#line 4557 "tth.lex"
 yyless(0);TTH_SCAN_STRING("\\\\"); 
 	YY_BREAK
 case 702:
 YY_RULE_SETUP
-#line 4557 "tth.lex"
+#line 4559 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 case 703:
 YY_RULE_SETUP
-#line 4558 "tth.lex"
+#line 4560 "tth.lex"
 
 	YY_BREAK
 case 704:
 /* rule 704 can match eol */
 YY_RULE_SETUP
-#line 4559 "tth.lex"
+#line 4561 "tth.lex"
 TTH_INC_MULTI;TTH_OUTPUT("</tr><tr><td>");
 	YY_BREAK
 /* End of tabular and halign code.*/
 /********************************************************************/
 case 705:
 YY_RULE_SETUP
-#line 4563 "tth.lex"
+#line 4565 "tth.lex"
 TTH_OUTPUT(TTH_TINY);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 706:
 YY_RULE_SETUP
-#line 4564 "tth.lex"
+#line 4566 "tth.lex"
 TTH_OUTPUT(TTH_SCRIPTSIZE);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 707:
 YY_RULE_SETUP
-#line 4565 "tth.lex"
+#line 4567 "tth.lex"
 TTH_OUTPUT(TTH_FOOTNOTESIZE);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 708:
 YY_RULE_SETUP
-#line 4566 "tth.lex"
+#line 4568 "tth.lex"
 TTH_OUTPUT(TTH_SMALL);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 709:
 YY_RULE_SETUP
-#line 4567 "tth.lex"
+#line 4569 "tth.lex"
 TTH_OUTPUT(TTH_NORMALSIZE);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 710:
 YY_RULE_SETUP
-#line 4568 "tth.lex"
+#line 4570 "tth.lex"
 TTH_OUTPUT(TTH_large);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 711:
 YY_RULE_SETUP
-#line 4569 "tth.lex"
+#line 4571 "tth.lex"
 TTH_OUTPUT(TTH_Large);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 712:
 YY_RULE_SETUP
-#line 4570 "tth.lex"
+#line 4572 "tth.lex"
 TTH_OUTPUT(TTH_LARGE);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 713:
 YY_RULE_SETUP
-#line 4571 "tth.lex"
+#line 4573 "tth.lex"
 TTH_OUTPUT(TTH_HUGE);TTH_PRECLOSE(TTH_SIZEEND);
 	YY_BREAK
 case 714:
 YY_RULE_SETUP
-#line 4573 "tth.lex"
+#line 4575 "tth.lex"
 fprintf(tth_fdout,"<div style=\"text-align:center\">");TTH_PRECLOSE("</div>");
 	YY_BREAK
 case 715:
 YY_RULE_SETUP
-#line 4574 "tth.lex"
+#line 4576 "tth.lex"
 fprintf(tth_fdout,"<div align=\"right\">");TTH_PRECLOSE("</div>");
 	YY_BREAK
 /* Insert an implied hbox around the minipage(s) that terminates at the
@@ -21646,7 +21648,7 @@ fprintf(tth_fdout,"<div align=\"right\">");TTH_PRECLOSE("</div>");
  */
 case 716:
 YY_RULE_SETUP
-#line 4580 "tth.lex"
+#line 4582 "tth.lex"
 {
   yy_push_state(INITIAL);
   TTH_TEX_FN_OPT("\\vbox\\bgroup\\hsize=#2#tthdrop2",2,"");
@@ -21654,7 +21656,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 717:
 YY_RULE_SETUP
-#line 4584 "tth.lex"
+#line 4586 "tth.lex"
 {
   TTH_PUSH_CLOSING; /* This will be cancelled at the end of the pargroup*/
   yy_push_state(pargroup);
@@ -21664,7 +21666,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 718:
 YY_RULE_SETUP
-#line 4590 "tth.lex"
+#line 4592 "tth.lex"
 {
   TTH_SCAN_STRING("\\egroup");
   yy_pop_state();
@@ -21674,29 +21676,29 @@ YY_RULE_SETUP
 /* colordvi-compatible commands. Expand the argument first.*/
 case 719:
 YY_RULE_SETUP
-#line 4598 "tth.lex"
+#line 4600 "tth.lex"
 TTH_TEX_FN("{\\textColor{#1}#2}#tthdrop2",2);
 	YY_BREAK
 /* textColor in colordvi is global. But that's a terrible thing to do 
     so in TtH it is local. */
 case 720:
 YY_RULE_SETUP
-#line 4601 "tth.lex"
+#line 4603 "tth.lex"
 TTH_TEX_FN("\\edef\\tthexpcol{\\tthtextColor{#1}}\\tthexpcol#tthdrop1",1);
 	YY_BREAK
 case 721:
 /* rule 721 can match eol */
-#line 4603 "tth.lex"
+#line 4605 "tth.lex"
 case 722:
 /* rule 722 can match eol */
-#line 4604 "tth.lex"
+#line 4606 "tth.lex"
 case 723:
 /* rule 723 can match eol */
-#line 4605 "tth.lex"
+#line 4607 "tth.lex"
 case 724:
 /* rule 724 can match eol */
 YY_RULE_SETUP
-#line 4605 "tth.lex"
+#line 4607 "tth.lex"
 { /* Color defined in one of four ways*/
   chscratch=yytext+strcspn(yytext,"{")+1;
   *(chscratch+strcspn(chscratch,"}"))=0;
@@ -21765,14 +21767,14 @@ YY_RULE_SETUP
 case 725:
 /* rule 725 can match eol */
 YY_RULE_SETUP
-#line 4669 "tth.lex"
+#line 4671 "tth.lex"
 TTH_INC_MULTI;
 	YY_BREAK
 /* TTH_OUTPUT(TTH_COLOREND); Remove because nesting gets broken */
 case 726:
 /* rule 726 can match eol */
 YY_RULE_SETUP
-#line 4671 "tth.lex"
+#line 4673 "tth.lex"
 {
   TTH_INC_MULTI;
   TTH_CCPY(scratchstring,"\\tthspecialcolor{");
@@ -21788,42 +21790,42 @@ YY_RULE_SETUP
     but color is the switch. Use the preceding function anyway.*/
 case 727:
 YY_RULE_SETUP
-#line 4684 "tth.lex"
+#line 4686 "tth.lex"
 TTH_TEX_FN_OPT("{\\textColor{#2}#3}#tthdrop3",3,"");
 	YY_BREAK
 case 728:
 YY_RULE_SETUP
-#line 4685 "tth.lex"
+#line 4687 "tth.lex"
 TTH_TEX_FN_OPT("\\edef\\tthexpcol{\\tthtextColor{#2}}\\tthexpcol#tthdrop2",2,"");
 	YY_BREAK
 case 729:
 YY_RULE_SETUP
-#line 4686 "tth.lex"
+#line 4688 "tth.lex"
 TTH_TEX_FN_OPT("{\\edef\\tthexpcol{\\tthbgColor{#2}}\\tthexpcol #3}#tthdrop3",3,"");
 	YY_BREAK
 case 730:
 YY_RULE_SETUP
-#line 4687 "tth.lex"
+#line 4689 "tth.lex"
 TTH_TEX_FN_OPT("\\fbox{\\colorbox[#1]{#2}{#3}}#tthdrop3",3,"");
 	YY_BREAK
 case 731:
 YY_RULE_SETUP
-#line 4688 "tth.lex"
+#line 4690 "tth.lex"
 TTH_TEX_FN_OPT("{\\edef\\tthexpcol{\\tthpageColor{#2}}\\tthexpcol}#tthdrop2",2,"");
 	YY_BREAK
 case 732:
-#line 4691 "tth.lex"
-case 733:
-#line 4692 "tth.lex"
-case 734:
 #line 4693 "tth.lex"
-case 735:
+case 733:
 #line 4694 "tth.lex"
-case 736:
+case 734:
 #line 4695 "tth.lex"
+case 735:
+#line 4696 "tth.lex"
+case 736:
+#line 4697 "tth.lex"
 case 737:
 YY_RULE_SETUP
-#line 4695 "tth.lex"
+#line 4697 "tth.lex"
 {
   localdef=1;
   horizmode=0; /* This protection against \par should not be needed but ...*/
@@ -21835,7 +21837,7 @@ YY_RULE_SETUP
 case 738:
 /* rule 738 can match eol */
 YY_RULE_SETUP
-#line 4702 "tth.lex"
+#line 4704 "tth.lex"
 {
   fprintf(stderr,"**** %s: works only for non-standard environments\n",yytext);
   strcpy(scratchstring,"\\newenvironment");
@@ -21846,7 +21848,7 @@ YY_RULE_SETUP
 case 739:
 /* rule 739 can match eol */
 YY_RULE_SETUP
-#line 4708 "tth.lex"
+#line 4710 "tth.lex"
 {
   localdef=0;
   horizmode=0;
@@ -21862,7 +21864,7 @@ YY_RULE_SETUP
 case 740:
 /* rule 740 can match eol */
 YY_RULE_SETUP
-#line 4719 "tth.lex"
+#line 4721 "tth.lex"
 { 
   TTH_INC_MULTI;
   /* Newtheorem with numberedlike option. Overrides macro definition.*/
@@ -21881,7 +21883,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 741:
 YY_RULE_SETUP
-#line 4734 "tth.lex"
+#line 4736 "tth.lex"
 {
   yyless(0);yy_pop_state();
   yy_push_state(define);
@@ -21893,7 +21895,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 742:
 YY_RULE_SETUP
-#line 4743 "tth.lex"
+#line 4745 "tth.lex"
 {
   if(indexkey("\\amslatex",keys,&nkeys)!=-1){
     TTH_SCAN_STRING("\\verb|");
@@ -21904,11 +21906,11 @@ YY_RULE_SETUP
 	YY_BREAK
 /* url that does not use braces */
 case 743:
-#line 4752 "tth.lex"
+#line 4754 "tth.lex"
 /*\\verb\*?[^ \t\na] { prior to 12 Jan 2002*/
 case 744:
 YY_RULE_SETUP
-#line 4753 "tth.lex"
+#line 4755 "tth.lex"
 {  /* Prevent erroneous \verbatim detection */
   if(tth_debug&8)fprintf(stderr,"Entering Verb state:%s\n",yytext);
   chr1[0]=*(yytext+strlen(yytext)-1);
@@ -21919,7 +21921,7 @@ YY_RULE_SETUP
 /* Deal with cases that are not in line.*/
 case 745:
 YY_RULE_SETUP
-#line 4760 "tth.lex"
+#line 4762 "tth.lex"
 TTH_TEX_FN("\\verb#1#tthdrop1",1);
 	YY_BREAK
 /* ************* Enclosing multiple groups in stuff. ******** removed **/
@@ -21927,19 +21929,19 @@ TTH_TEX_FN("\\verb#1#tthdrop1",1);
 case 746:
 /* rule 746 can match eol */
 YY_RULE_SETUP
-#line 4765 "tth.lex"
+#line 4767 "tth.lex"
 {
   TTH_INC_LINE;yy_pop_state();TTH_SCAN_STRING("\\par\n");horizmode=1;}
 	YY_BREAK
 case 747:
 YY_RULE_SETUP
-#line 4767 "tth.lex"
+#line 4769 "tth.lex"
 {yyless(0);yy_pop_state();horizmode=1;}
 	YY_BREAK
 case 748:
 /* rule 748 can match eol */
 YY_RULE_SETUP
-#line 4769 "tth.lex"
+#line 4771 "tth.lex"
 {
   TTH_INC_LINE;
   if(horizmode==1){
@@ -21954,7 +21956,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 749:
 YY_RULE_SETUP
-#line 4780 "tth.lex"
+#line 4782 "tth.lex"
 {
   TTH_TEXCLOSE else{
     TTH_CLOSEGROUP;TTH_POP_CLOSING;
@@ -21966,7 +21968,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 750:
 YY_RULE_SETUP
-#line 4788 "tth.lex"
+#line 4790 "tth.lex"
 {
   TTH_TEXCLOSE else{ 
     if(!strcmp(closing,"</dd></dl>")) {
@@ -21984,7 +21986,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 751:
 YY_RULE_SETUP
-#line 4802 "tth.lex"
+#line 4804 "tth.lex"
 {
   TTH_TEXCLOSE else{
     if(!strcmp(closing,"</dd></dl></dl>")) {
@@ -22001,24 +22003,24 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 752:
-#line 4818 "tth.lex"
+#line 4820 "tth.lex"
 case 753:
-#line 4819 "tth.lex"
+#line 4821 "tth.lex"
 case 754:
 YY_RULE_SETUP
-#line 4819 "tth.lex"
+#line 4821 "tth.lex"
 {
   sprintf(scratchstring,"\\par%s",yytext); TTH_SCAN_STRING(scratchstring);
 }
 	YY_BREAK
 /* Fix for \hang and friends end of a vbox implies a par */
 case 755:
-#line 4824 "tth.lex"
+#line 4826 "tth.lex"
 case 756:
-#line 4825 "tth.lex"
+#line 4827 "tth.lex"
 case 757:
 YY_RULE_SETUP
-#line 4825 "tth.lex"
+#line 4827 "tth.lex"
 {
   if(strstr(closing,"--vbox")){
     TTH_SCAN_STRING("\\par}");
@@ -22029,7 +22031,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 758:
 YY_RULE_SETUP
-#line 4834 "tth.lex"
+#line 4836 "tth.lex"
 {
   if(strstr(tth_texclose[tth_push_depth-1],"\\tthhbclose")){
     if(tth_debug&1024){
@@ -22045,7 +22047,7 @@ YY_RULE_SETUP
 case 759:
 /* rule 759 can match eol */
 YY_RULE_SETUP
-#line 4845 "tth.lex"
+#line 4847 "tth.lex"
 {
   TTH_CHECK_LENGTH;
   if(bracecount) fprintf(stderr,
@@ -22063,7 +22065,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 760:
 YY_RULE_SETUP
-#line 4860 "tth.lex"
+#line 4862 "tth.lex"
 {
   if(horizmode) {
     {TTH_PAR_ACTION}
@@ -22073,7 +22075,7 @@ YY_RULE_SETUP
 case 761:
 /* rule 761 can match eol */
 YY_RULE_SETUP
-#line 4866 "tth.lex"
+#line 4868 "tth.lex"
 {
   TTH_CHECK_LENGTH;
   if(bracecount) fprintf(stderr,"**** Error. Bracecount=%d nonzero, line %d\n",
@@ -22092,7 +22094,7 @@ YY_RULE_SETUP
 /*************************** General Rules. *****************/
 case 762:
 YY_RULE_SETUP
-#line 4882 "tth.lex"
+#line 4884 "tth.lex"
 {
   TTH_PUSH_CLOSING; fprintf(tth_fdout,"\n<h2> ");
   TTH_CCPY(closing,"</h2>\n");
@@ -22100,7 +22102,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 763:
 YY_RULE_SETUP
-#line 4886 "tth.lex"
+#line 4888 "tth.lex"
 {
   TTH_OUTPUT("\n<table align=\"center\" border=\"0\"><tr><td>\n");
   TTH_CCPY(argchar,"</td></tr></table><!--hboxt-->");
@@ -22109,37 +22111,37 @@ YY_RULE_SETUP
 	YY_BREAK
 case 764:
 YY_RULE_SETUP
-#line 4891 "tth.lex"
+#line 4893 "tth.lex"
 {
   fprintf(tth_fdout,"\n<br />");yy_push_state(tokenarg);
   TTH_CCPY(argchar,"<br />");}
 	YY_BREAK
 case 765:
-#line 4897 "tth.lex"
-case 766:
-#line 4898 "tth.lex"
-case 767:
 #line 4899 "tth.lex"
+case 766:
+#line 4900 "tth.lex"
+case 767:
+#line 4901 "tth.lex"
 case 768:
 YY_RULE_SETUP
-#line 4899 "tth.lex"
+#line 4901 "tth.lex"
 TTH_SWAP("\\tth_underline ");
 	YY_BREAK
 case 769:
 YY_RULE_SETUP
-#line 4900 "tth.lex"
+#line 4902 "tth.lex"
 yy_push_state(ruledim);TTH_OUTPUT("<hr />\n");
 	YY_BREAK
 case 770:
 YY_RULE_SETUP
-#line 4901 "tth.lex"
+#line 4903 "tth.lex"
 yy_push_state(ruledim);
 	YY_BREAK
 case 771:
-#line 4903 "tth.lex"
+#line 4905 "tth.lex"
 case 772:
 YY_RULE_SETUP
-#line 4903 "tth.lex"
+#line 4905 "tth.lex"
 {
   /*  if(horizmode) {fprintf(tth_fdout,TTH_PAR);horizmode=0;} replaced by*/
   if(horizmode) {{TTH_PAR_ACTION}}
@@ -22147,22 +22149,22 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 773:
-#line 4909 "tth.lex"
+#line 4911 "tth.lex"
 case 774:
 YY_RULE_SETUP
-#line 4909 "tth.lex"
+#line 4911 "tth.lex"
 {
   if(horizmode) {{TTH_PAR_ACTION}}
   fprintf(tth_fdout,"<br />");
 }
 	YY_BREAK
 case 775:
-#line 4914 "tth.lex"
+#line 4916 "tth.lex"
 case 776:
-#line 4915 "tth.lex"
+#line 4917 "tth.lex"
 case 777:
 YY_RULE_SETUP
-#line 4915 "tth.lex"
+#line 4917 "tth.lex"
 {
   if(horizmode) {{TTH_PAR_ACTION}}
 }
@@ -22171,7 +22173,7 @@ YY_RULE_SETUP
 case 778:
 /* rule 778 can match eol */
 YY_RULE_SETUP
-#line 4920 "tth.lex"
+#line 4922 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{TTH_INC_MULTI;TTH_OUTPUT("<br />");}
 }
@@ -22180,7 +22182,7 @@ YY_RULE_SETUP
 case 779:
 /* rule 779 can match eol */
 YY_RULE_SETUP
-#line 4924 "tth.lex"
+#line 4926 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{GET_DIMEN;}
 }
@@ -22189,7 +22191,7 @@ YY_RULE_SETUP
 case 780:
 /* rule 780 can match eol */
 YY_RULE_SETUP
-#line 4928 "tth.lex"
+#line 4930 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{    /* Fix tth-comment before item bug. */
     TTH_INC_MULTI;
@@ -22205,7 +22207,7 @@ YY_RULE_SETUP
 case 781:
 /* rule 781 can match eol */
 YY_RULE_SETUP
-#line 4939 "tth.lex"
+#line 4941 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{    /* Fix tth-comment before item bug. */
     TTH_INC_MULTI;
@@ -22225,18 +22227,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 782:
 YY_RULE_SETUP
-#line 4955 "tth.lex"
+#line 4957 "tth.lex"
 fprintf(tth_fdout,"<br />&nbsp;&nbsp;&nbsp;&nbsp;");
 	YY_BREAK
 case 783:
 YY_RULE_SETUP
-#line 4956 "tth.lex"
+#line 4958 "tth.lex"
 fprintf(tth_fdout,"<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
 	YY_BREAK
 case 784:
 /* rule 784 can match eol */
 YY_RULE_SETUP
-#line 4957 "tth.lex"
+#line 4959 "tth.lex"
 { /* Space might not mean no opt. */ 
   /* If we can immediately detect absence of opt arg. Don't put dt section*/
   TTH_INC_MULTI;
@@ -22250,7 +22252,7 @@ YY_RULE_SETUP
 case 785:
 /* rule 785 can match eol */
 YY_RULE_SETUP
-#line 4966 "tth.lex"
+#line 4968 "tth.lex"
 { /* If opt arg absent just gives null dt*/
   TTH_EXTRACT_COMMENT{    /* Fix tth-comment before item bug. */
   TTH_INC_MULTI;
@@ -22263,7 +22265,7 @@ YY_RULE_SETUP
 case 786:
 /* rule 786 can match eol */
 YY_RULE_SETUP
-#line 4974 "tth.lex"
+#line 4976 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{    /* Fix tth-comment before item bug. */
   TTH_INC_MULTI;
@@ -22276,7 +22278,7 @@ YY_RULE_SETUP
 case 787:
 /* rule 787 can match eol */
 YY_RULE_SETUP
-#line 4982 "tth.lex"
+#line 4984 "tth.lex"
 {
   TTH_EXTRACT_COMMENT{    /* Fix tth-comment before item bug. */
   TTH_INC_MULTI;
@@ -22288,7 +22290,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 788:
 YY_RULE_SETUP
-#line 4990 "tth.lex"
+#line 4992 "tth.lex"
 {
   fprintf(tth_fdout,"%s","\n<dl>\n <dt>\n");TTH_PUSH_CLOSING;
   TTH_CCPY(closing,"</dd></dl>");
@@ -22299,7 +22301,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 789:
 YY_RULE_SETUP
-#line 4997 "tth.lex"
+#line 4999 "tth.lex"
 {
   fprintf(tth_fdout,"\n<dl><dd><dl><dt>");TTH_PUSH_CLOSING;
   TTH_CCPY(closing,"</dd></dl></dd></dl>");
@@ -22310,12 +22312,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 790:
 YY_RULE_SETUP
-#line 5004 "tth.lex"
+#line 5006 "tth.lex"
 {TTH_PUSH_CLOSING;fprintf(tth_fdout,"\n<br />");}
 	YY_BREAK
 case 791:
 YY_RULE_SETUP
-#line 5005 "tth.lex"
+#line 5007 "tth.lex"
 {
   TTH_TEXCLOSE else{
     TTH_CLOSEGROUP;TTH_POP_CLOSING;fprintf(tth_fdout,"\n<br />");}
@@ -22323,7 +22325,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 792:
 YY_RULE_SETUP
-#line 5010 "tth.lex"
+#line 5012 "tth.lex"
 {  /* Now using embracetok Sep 98*/
   ftntno++;
   tth_encode(ftntcode,ftntno);
@@ -22352,7 +22354,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 793:
 YY_RULE_SETUP
-#line 5036 "tth.lex"
+#line 5038 "tth.lex"
 { /* xdef footnote with reference.*/
   if(tth_debug&4) fprintf(stderr,"tthfootnote, dupstore=%s\n",dupstore);
   TTH_OUTPUT("</a>");  /* end the anchors */
@@ -22364,7 +22366,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 794:
 YY_RULE_SETUP
-#line 5045 "tth.lex"
+#line 5047 "tth.lex"
 {
   yy_push_state(uppercase);
   tth_push_depth--;
@@ -22374,7 +22376,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 795:
 YY_RULE_SETUP
-#line 5051 "tth.lex"
+#line 5053 "tth.lex"
 {
   for(jscratch=0;jscratch<strlen(yytext);jscratch++) {
     *(yytext+jscratch)=toupper(*(yytext+jscratch));}
@@ -22382,10 +22384,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 796:
-#line 5057 "tth.lex"
+#line 5059 "tth.lex"
 case 797:
 YY_RULE_SETUP
-#line 5057 "tth.lex"
+#line 5059 "tth.lex"
 {
   *(yytext+strlen(yytext)-1)=toupper(*(yytext+strlen(yytext)-1));
   TTH_SCAN_STRING(yytext);
@@ -22393,11 +22395,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 798:
 /* rule 798 can match eol */
-#line 5063 "tth.lex"
+#line 5065 "tth.lex"
 case 799:
 /* rule 799 can match eol */
 YY_RULE_SETUP
-#line 5063 "tth.lex"
+#line 5065 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_push_state(htemplate);
@@ -22414,7 +22416,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 800:
 YY_RULE_SETUP
-#line 5076 "tth.lex"
+#line 5078 "tth.lex"
 {
  strcpy(scratchstring," border=\"1\"");
  TTH_CCAT(scrstring,yytext);
@@ -22423,7 +22425,7 @@ YY_RULE_SETUP
 /* Add template interpretation into && strings and alignment.*/
 case 801:
 YY_RULE_SETUP
-#line 5081 "tth.lex"
+#line 5083 "tth.lex"
 {
   TTH_CCAT(halstring,tdalign);
   /*  TTH_CCAT(scrstring,"}&|");  */
@@ -22442,7 +22444,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 802:
 YY_RULE_SETUP
-#line 5096 "tth.lex"
+#line 5098 "tth.lex"
 {
   if(*tdalign==0) {
     strcpy(tdalign,"r"); 
@@ -22454,7 +22456,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 803:
 YY_RULE_SETUP
-#line 5104 "tth.lex"
+#line 5106 "tth.lex"
 {
   ncols++;
   TTH_CCAT(scrstring,"&");
@@ -22464,21 +22466,21 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 804:
-#line 5112 "tth.lex"
+#line 5114 "tth.lex"
 case 805:
 /* rule 805 can match eol */
 YY_RULE_SETUP
-#line 5112 "tth.lex"
+#line 5114 "tth.lex"
 TTH_INC_LINE;TTH_CCAT(scrstring,yytext);
 	YY_BREAK
 case 806:
 YY_RULE_SETUP
-#line 5113 "tth.lex"
+#line 5115 "tth.lex"
 TTH_CCAT(scrstring,yytext);
 	YY_BREAK
 case 807:
 YY_RULE_SETUP
-#line 5114 "tth.lex"
+#line 5116 "tth.lex"
 { /* New version uses the scanning of template. */
   /*
   TTH_CCAT(scrstring,"&");  
@@ -22503,7 +22505,7 @@ YY_RULE_SETUP
 case 808:
 /* rule 808 can match eol */
 YY_RULE_SETUP
-#line 5136 "tth.lex"
+#line 5138 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_push_state(valign);
@@ -22517,12 +22519,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 809:
 YY_RULE_SETUP
-#line 5147 "tth.lex"
+#line 5149 "tth.lex"
 valsec++;
 	YY_BREAK
 case 810:
 YY_RULE_SETUP
-#line 5148 "tth.lex"
+#line 5150 "tth.lex"
 {
   if(valsec){
     if(*valignstring){
@@ -22537,49 +22539,49 @@ YY_RULE_SETUP
 	YY_BREAK
 case 811:
 YY_RULE_SETUP
-#line 5159 "tth.lex"
+#line 5161 "tth.lex"
 {
   fprintf(tth_fdout,"\n<table class=\"tabular\"><tr><td%s>",valignstring);
   yy_pop_state();
 }    
 	YY_BREAK
 case 812:
-#line 5166 "tth.lex"
+#line 5168 "tth.lex"
 case 813:
 YY_RULE_SETUP
-#line 5166 "tth.lex"
+#line 5168 "tth.lex"
 {
   yy_pop_state();
 }
 	YY_BREAK
 /* altered approach to input*/
 case 814:
-#line 5171 "tth.lex"
+#line 5173 "tth.lex"
 case 815:
-#line 5172 "tth.lex"
+#line 5174 "tth.lex"
 case 816:
 YY_RULE_SETUP
-#line 5172 "tth.lex"
+#line 5174 "tth.lex"
 yy_push_state(inputfile);yy_push_state(removespace); 
 	YY_BREAK
 case YY_STATE_EOF(inputfile):
-#line 5173 "tth.lex"
+#line 5175 "tth.lex"
 TTH_SCAN_STRING(" \\tth_eof");
 	YY_BREAK
 case 817:
 /* rule 817 can match eol */
-#line 5175 "tth.lex"
+#line 5177 "tth.lex"
 case 818:
 /* rule 818 can match eol */
 YY_RULE_SETUP
-#line 5175 "tth.lex"
+#line 5177 "tth.lex"
 TTH_INC_LINE;TTH_SCAN_STRING(" ");
 	YY_BREAK
 case 819:
-#line 5177 "tth.lex"
+#line 5179 "tth.lex"
 case 820:
 YY_RULE_SETUP
-#line 5177 "tth.lex"
+#line 5179 "tth.lex"
 {
     if ( tth_stack_ptr >= MAX_INCLUDE_DEPTH )
       {
@@ -22630,23 +22632,23 @@ YY_RULE_SETUP
 	YY_BREAK
 case 821:
 YY_RULE_SETUP
-#line 5224 "tth.lex"
+#line 5226 "tth.lex"
 
 	YY_BREAK
 case 822:
 YY_RULE_SETUP
-#line 5225 "tth.lex"
+#line 5227 "tth.lex"
 TTH_CCAT(input_filename,yytext);
 	YY_BREAK
 /* Specific internal commands to expand in inputfile */
 case 823:
 YY_RULE_SETUP
-#line 5227 "tth.lex"
+#line 5229 "tth.lex"
 TTH_SCAN_STRING(tth_latex_file);
 	YY_BREAK
 case 824:
 YY_RULE_SETUP
-#line 5228 "tth.lex"
+#line 5230 "tth.lex"
 {
   TTH_DO_MACRO
     else{
@@ -22656,11 +22658,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 825:
 /* rule 825 can match eol */
-#line 5236 "tth.lex"
+#line 5238 "tth.lex"
 case 826:
 /* rule 826 can match eol */
 YY_RULE_SETUP
-#line 5236 "tth.lex"
+#line 5238 "tth.lex"
 {
 #ifdef MSDOS
     /* pointer reading is broken in DJGPP */
@@ -22683,7 +22685,7 @@ YY_RULE_SETUP
 case 827:
 /* rule 827 can match eol */
 YY_RULE_SETUP
-#line 5255 "tth.lex"
+#line 5257 "tth.lex"
 {
   TTH_INC_MULTI;
  if(tth_fontguess){/* Try to guess what size etc is being called for. */
@@ -22751,7 +22753,7 @@ YY_RULE_SETUP
 case 828:
 /* rule 828 can match eol */
 YY_RULE_SETUP
-#line 5318 "tth.lex"
+#line 5320 "tth.lex"
 {
   TTH_INC_MULTI;
   sprintf(newcstr,"\\tth_newcounter%s",strstr(yytext,"{"));
@@ -22761,7 +22763,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 829:
 YY_RULE_SETUP
-#line 5324 "tth.lex"
+#line 5326 "tth.lex"
 {
   if(tth_debug&4)fprintf(stderr,"Newcounter: %s\n",yytext);
   strcpy(dupstore2,"\\");strcat(dupstore2,yytext+strcspn(yytext,"{")+1);
@@ -22803,7 +22805,7 @@ YY_RULE_SETUP
 case 830:
 /* rule 830 can match eol */
 YY_RULE_SETUP
-#line 5361 "tth.lex"
+#line 5363 "tth.lex"
 {
   TTH_INC_MULTI;
   if(tth_debug&4)fprintf(stderr,"Setcounter: %s\n",yytext);
@@ -22827,12 +22829,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 831:
 YY_RULE_SETUP
-#line 5381 "tth.lex"
+#line 5383 "tth.lex"
 iac=-1;yy_push_state(advance);  yy_push_state(removespace);
 	YY_BREAK
 case 832:
 YY_RULE_SETUP
-#line 5382 "tth.lex"
+#line 5384 "tth.lex"
 {
   if(strstr(yytext,"alph")) jscratch=1;
   else if(strstr(yytext,"Alph")) jscratch=2;
@@ -22850,7 +22852,7 @@ YY_RULE_SETUP
 case 833:
 /* rule 833 can match eol */
 YY_RULE_SETUP
-#line 5395 "tth.lex"
+#line 5397 "tth.lex"
 {
   TTH_INC_MULTI;
   strcpy(scratchstring,yytext+strcspn(yytext,"{"));
@@ -22880,7 +22882,7 @@ YY_RULE_SETUP
 case 834:
 /* rule 834 can match eol */
 YY_RULE_SETUP
-#line 5420 "tth.lex"
+#line 5422 "tth.lex"
 {
   TTH_INC_MULTI;
   chscratch=yytext+strcspn(yytext,"{")+1;
@@ -22911,31 +22913,31 @@ YY_RULE_SETUP
 /* TeX counters */
 case 835:
 YY_RULE_SETUP
-#line 5448 "tth.lex"
+#line 5450 "tth.lex"
 {
   if(horizmode)horizmode=1;yy_push_state(getcount);yy_push_state(removespace);}
 	YY_BREAK
 case 836:
 YY_RULE_SETUP
-#line 5450 "tth.lex"
+#line 5452 "tth.lex"
 {
   mkkey(yytext,countkeys,&ncounters);yy_pop_state();
  }
 	YY_BREAK
 case 837:
 YY_RULE_SETUP
-#line 5453 "tth.lex"
+#line 5455 "tth.lex"
 fprintf(stderr,"Ill-formed newcount");yy_pop_state();
 	YY_BREAK
 case 838:
 YY_RULE_SETUP
-#line 5456 "tth.lex"
+#line 5458 "tth.lex"
 {iac=-1;yy_push_state(advance);if(horizmode)horizmode=1;}
 	YY_BREAK
 case 839:
 /* rule 839 can match eol */
 YY_RULE_SETUP
-#line 5458 "tth.lex"
+#line 5460 "tth.lex"
 TTH_INC_MULTI;
 	YY_BREAK
 /*
@@ -22948,7 +22950,7 @@ TTH_INC_MULTI;
 case 840:
 /* rule 840 can match eol */
 YY_RULE_SETUP
-#line 5468 "tth.lex"
+#line 5470 "tth.lex"
 {
   /* Latex addtocounter. Convert into plain form. */
   TTH_INC_MULTI;
@@ -22967,12 +22969,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 841:
 YY_RULE_SETUP
-#line 5484 "tth.lex"
+#line 5486 "tth.lex"
 
 	YY_BREAK
 case 842:
 YY_RULE_SETUP
-#line 5485 "tth.lex"
+#line 5487 "tth.lex"
 {/* Dimension advancing: get counter name.*/
   chscratch=yytext+strlen("\\tthdimen");
   strcpy(newcstr,chscratch+strspn(chscratch," "));
@@ -22986,7 +22988,7 @@ YY_RULE_SETUP
 case 843:
 /* rule 843 can match eol */
 YY_RULE_SETUP
-#line 5495 "tth.lex"
+#line 5497 "tth.lex"
 {
   yyless(0);
   if(!dimadvstate){ /* Return of first time we have the first num,unit. */
@@ -23009,16 +23011,16 @@ YY_RULE_SETUP
 	YY_BREAK
 case 844:
 YY_RULE_SETUP
-#line 5516 "tth.lex"
+#line 5518 "tth.lex"
 {
   if(strcspn(yytext,"-") < strlen(yytext)) minus=-1;
 }             
 	YY_BREAK
 case 845:
-#line 5520 "tth.lex"
+#line 5522 "tth.lex"
 case 846:
 YY_RULE_SETUP
-#line 5520 "tth.lex"
+#line 5522 "tth.lex"
 {
   if(iac==-1){ /* First time we are getting the one to set */ 
     iac=indexkey(yytext,countkeys,&ncounters);
@@ -23069,7 +23071,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 847:
 YY_RULE_SETUP
-#line 5567 "tth.lex"
+#line 5569 "tth.lex"
 {
   fprintf(stderr,"**** Error. Ill-formed \\advance statement\n");
   yy_pop_state();
@@ -23077,11 +23079,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 848:
 /* rule 848 can match eol */
-#line 5573 "tth.lex"
+#line 5575 "tth.lex"
 case 849:
 /* rule 849 can match eol */
 YY_RULE_SETUP
-#line 5573 "tth.lex"
+#line 5575 "tth.lex"
 {
   chscratch=strstr(yytext,"{");
   strcpy(scratchstring,chscratch);
@@ -23091,19 +23093,19 @@ YY_RULE_SETUP
   }
 	YY_BREAK
 case 850:
-#line 5582 "tth.lex"
-case 851:
-#line 5583 "tth.lex"
-case 852:
 #line 5584 "tth.lex"
+case 851:
+#line 5585 "tth.lex"
+case 852:
+#line 5586 "tth.lex"
 case 853:
 YY_RULE_SETUP
-#line 5584 "tth.lex"
+#line 5586 "tth.lex"
 yy_push_state(number);jscratch=0;
 	YY_BREAK
 case 854:
 YY_RULE_SETUP
-#line 5585 "tth.lex"
+#line 5587 "tth.lex"
 {
   i=indexkey(yytext,countkeys,&ncounters);
   if(i == -1) {
@@ -23132,22 +23134,22 @@ YY_RULE_SETUP
 	YY_BREAK
 case 855:
 YY_RULE_SETUP
-#line 5610 "tth.lex"
+#line 5612 "tth.lex"
 fprintf(stderr,"No number at character:%s",yytext);yy_pop_state();
 	YY_BREAK
 case 856:
 YY_RULE_SETUP
-#line 5611 "tth.lex"
+#line 5613 "tth.lex"
 /* Remove optional = and space */
 	YY_BREAK
 case 857:
 YY_RULE_SETUP
-#line 5612 "tth.lex"
+#line 5614 "tth.lex"
 TTH_PUSH_CLOSING;
 	YY_BREAK
 case 858:
 YY_RULE_SETUP
-#line 5613 "tth.lex"
+#line 5615 "tth.lex"
 {
   sscanf(yytext+strcspn(yytext,"+-0123456789"),"%d",&counters[ind]);
   if(tth_debug&4) fprintf(stderr,"Counter %d set to %d\n",ind,counters[ind]);
@@ -23156,7 +23158,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 859:
 YY_RULE_SETUP
-#line 5618 "tth.lex"
+#line 5620 "tth.lex"
 {
   js2=ind; /* Save ind because it is used by TTH_DO_MACRO */
   i=indexkey(yytext+strcspn(yytext,"\\"),countkeys,&ncounters);
@@ -23180,7 +23182,7 @@ YY_RULE_SETUP
 case 860:
 /* rule 860 can match eol */
 YY_RULE_SETUP
-#line 5637 "tth.lex"
+#line 5639 "tth.lex"
 {
   fprintf(stderr,"**** Error: Failed to find value to set counter %s.\n",countkeys[ind]);
   yy_pop_state();
@@ -23189,7 +23191,7 @@ YY_RULE_SETUP
 /* Definitions */
 case 861:
 YY_RULE_SETUP
-#line 5644 "tth.lex"
+#line 5646 "tth.lex"
 {	
   localdef=1;
   if(tth_debug&4) fprintf(stderr,"%s(localdef=%d)",yytext,localdef);
@@ -23202,7 +23204,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 862:
 YY_RULE_SETUP
-#line 5653 "tth.lex"
+#line 5655 "tth.lex"
 {  /* others are the same as <define> */
   if(!bracecount){
     if(tth_debug&4) fprintf(stderr,"Close brace ending let,count=%d\n",
@@ -23246,7 +23248,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 863:
 YY_RULE_SETUP
-#line 5694 "tth.lex"
+#line 5696 "tth.lex"
 {
   if(*(yytext+1)!='d')localdef=0; else localdef=1;
   if(tth_debug&4) fprintf(stderr,"%s(localdef=%d)",yytext,localdef);
@@ -23257,7 +23259,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 864:
 YY_RULE_SETUP
-#line 5701 "tth.lex"
+#line 5703 "tth.lex"
 {
   if(*(yytext+1)!='e')localdef=0; else localdef=1;
   if(tth_debug&4) fprintf(stderr,"%s(localdef=%d)",yytext,localdef);
@@ -23270,22 +23272,22 @@ YY_RULE_SETUP
 case 865:
 /* rule 865 can match eol */
 YY_RULE_SETUP
-#line 5709 "tth.lex"
+#line 5711 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 866:
 YY_RULE_SETUP
-#line 5710 "tth.lex"
+#line 5712 "tth.lex"
 
 	YY_BREAK
 case 867:
 YY_RULE_SETUP
-#line 5711 "tth.lex"
+#line 5713 "tth.lex"
 yy_push_state(getdefbr);strcpy(dupstore,"{");
 	YY_BREAK
 case 868:
 YY_RULE_SETUP
-#line 5712 "tth.lex"
+#line 5714 "tth.lex"
 {  /* Really ought to match braces. */
   /*fprintf(stderr,"getdefbr strings:%s:%s:",yytext,dupstore);*/
   yy_pop_state();
@@ -23299,12 +23301,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 869:
 YY_RULE_SETUP
-#line 5722 "tth.lex"
+#line 5724 "tth.lex"
 strcat(dupstore,yytext);
 	YY_BREAK
 case 870:
 YY_RULE_SETUP
-#line 5723 "tth.lex"
+#line 5725 "tth.lex"
 {
   /*fprintf(stderr,"getdef string:%s:",yytext);*/
   TTH_CCPY(defchar,yytext+strspn(yytext,"{ \t\n"));
@@ -23315,7 +23317,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 871:
 YY_RULE_SETUP
-#line 5730 "tth.lex"
+#line 5732 "tth.lex"
 {
   fprintf(stderr,
 	  "\n**** Error: incompatible syntax in macro name:%s: Line %d\n",
@@ -23326,11 +23328,11 @@ YY_RULE_SETUP
 /* Latex form accommodates arg number perhaps WSP is wrong. */
 case 872:
 /* rule 872 can match eol */
-#line 5739 "tth.lex"
+#line 5741 "tth.lex"
 case 873:
 /* rule 873 can match eol */
 YY_RULE_SETUP
-#line 5739 "tth.lex"
+#line 5741 "tth.lex"
 { /* New pattern */
   /*  sscanf((yytext+strcspn(yytext,"] \t\n{")-1),"%d",&narg); */
   TTH_INC_MULTI;
@@ -23341,7 +23343,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 874:
 YY_RULE_SETUP
-#line 5746 "tth.lex"
+#line 5748 "tth.lex"
 {
   narg=0;
   yy_pop_state();
@@ -23351,7 +23353,7 @@ YY_RULE_SETUP
 case 875:
 /* rule 875 can match eol */
 YY_RULE_SETUP
-#line 5751 "tth.lex"
+#line 5753 "tth.lex"
 {
   if(tth_delimdef){
     yy_pop_state();
@@ -23383,7 +23385,7 @@ YY_RULE_SETUP
 case 876:
 /* rule 876 can match eol */
 YY_RULE_SETUP
-#line 5778 "tth.lex"
+#line 5780 "tth.lex"
 {
   if(!whitespace)strcat(dupstore," ");
   TTH_INC_LINE;
@@ -23401,17 +23403,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 877:
 YY_RULE_SETUP
-#line 5792 "tth.lex"
+#line 5794 "tth.lex"
 {if(!whitespace){strcat(dupstore," ");} whitespace=1; }
 	YY_BREAK
 case 878:
 YY_RULE_SETUP
-#line 5793 "tth.lex"
+#line 5795 "tth.lex"
 {whitespace=1;strcat(dupstore,yytext);}
 	YY_BREAK
 case 879:
 YY_RULE_SETUP
-#line 5794 "tth.lex"
+#line 5796 "tth.lex"
 {
   whitespace=0;strcat(dupstore,yytext);horizmode=1;
     lkeys[nkeys]=0;
@@ -23426,18 +23428,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 880:
 YY_RULE_SETUP
-#line 5805 "tth.lex"
+#line 5807 "tth.lex"
 {whitespace=0;strcat(dupstore,yytext+1);horizmode=1;}
 	YY_BREAK
 case 881:
 YY_RULE_SETUP
-#line 5806 "tth.lex"
+#line 5808 "tth.lex"
 {whitespace=0;strcat(dupstore,yytext);horizmode=1;}
 	YY_BREAK
 case 882:
 /* rule 882 can match eol */
 YY_RULE_SETUP
-#line 5808 "tth.lex"
+#line 5810 "tth.lex"
 { 
   TTH_INC_MULTI;
   strcpy(scratchstring,yytext);
@@ -23455,23 +23457,23 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 883:
-#line 5825 "tth.lex"
+#line 5827 "tth.lex"
 case 884:
-#line 5826 "tth.lex"
+#line 5828 "tth.lex"
 case 885:
 YY_RULE_SETUP
-#line 5826 "tth.lex"
+#line 5828 "tth.lex"
 TTH_PUSH_CLOSING;
 	YY_BREAK
 case 886:
-#line 5828 "tth.lex"
-case 887:
-#line 5829 "tth.lex"
-case 888:
 #line 5830 "tth.lex"
+case 887:
+#line 5831 "tth.lex"
+case 888:
+#line 5832 "tth.lex"
 case 889:
 YY_RULE_SETUP
-#line 5830 "tth.lex"
+#line 5832 "tth.lex"
 {
   TTH_TEXCLOSE else{
 /*    if(horizmode==-1)horizmode=1;  */
@@ -23480,37 +23482,37 @@ YY_RULE_SETUP
 	YY_BREAK
 case 890:
 YY_RULE_SETUP
-#line 5835 "tth.lex"
+#line 5837 "tth.lex"
 bracecount++;
 	YY_BREAK
 case 891:
 YY_RULE_SETUP
-#line 5836 "tth.lex"
+#line 5838 "tth.lex"
 {if(!bracecount){yy_pop_state();} else {bracecount--;}}
 	YY_BREAK
 case 892:
 YY_RULE_SETUP
-#line 5837 "tth.lex"
+#line 5839 "tth.lex"
 
 	YY_BREAK
 case 893:
 YY_RULE_SETUP
-#line 5838 "tth.lex"
+#line 5840 "tth.lex"
 
 	YY_BREAK
 case 894:
 YY_RULE_SETUP
-#line 5839 "tth.lex"
+#line 5841 "tth.lex"
 
 	YY_BREAK
 case 895:
 YY_RULE_SETUP
-#line 5841 "tth.lex"
+#line 5843 "tth.lex"
 if(!tth_LaTeX) fprintf(tth_fdout,"<table class=\"tabbing\"><tr><td width=\"%d\">\n",tabwidth);
 	YY_BREAK
 case 896:
 YY_RULE_SETUP
-#line 5843 "tth.lex"
+#line 5845 "tth.lex"
 {
   sscanf(yytext+8,"%d",&jscratch);
   tabwidth=1000/jscratch;
@@ -23518,18 +23520,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 897:
 YY_RULE_SETUP
-#line 5847 "tth.lex"
+#line 5849 "tth.lex"
 {TTH_PAR_ACTION};
 	YY_BREAK
 /* Standard TeX formatting switches work properly inside groups.*/
 case 898:
 YY_RULE_SETUP
-#line 5850 "tth.lex"
+#line 5852 "tth.lex"
 fprintf(tth_fdout,"<pre>");TTH_PRECLOSE("\n</pre>");
 	YY_BREAK
 case 899:
 YY_RULE_SETUP
-#line 5851 "tth.lex"
+#line 5853 "tth.lex"
 { /* underline switch. */
   if(eqdepth && strcspn(TTH_NAME,"M")>0 ){ /* In equations not Mathml */
     TTH_CCAT(tth_font_open[tth_push_depth],TTH_UNDL1);
@@ -23541,7 +23543,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 900:
 YY_RULE_SETUP
-#line 5859 "tth.lex"
+#line 5861 "tth.lex"
 {
   if(eqdepth){
     TTH_CCAT(tth_font_open[tth_push_depth],TTH_BOLDO);
@@ -23556,7 +23558,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 901:
 YY_RULE_SETUP
-#line 5870 "tth.lex"
+#line 5872 "tth.lex"
 {
   if(eqdepth){
     TTH_CCPY(tth_font_open[tth_push_depth],TTH_BOLDO);
@@ -23572,7 +23574,7 @@ YY_RULE_SETUP
 /* Implementation of \bm from math package. Bold italic.*/
 case 902:
 YY_RULE_SETUP
-#line 5882 "tth.lex"
+#line 5884 "tth.lex"
 {
   if(eqdepth){
     TTH_CCPY(tth_font_open[tth_push_depth],TTH_BLDITO);
@@ -23586,10 +23588,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 903:
-#line 5894 "tth.lex"
+#line 5896 "tth.lex"
 case 904:
 YY_RULE_SETUP
-#line 5894 "tth.lex"
+#line 5896 "tth.lex"
 {
   if(eqdepth){
     TTH_CCAT(tth_font_open[tth_push_depth],TTH_ITALO);
@@ -23603,10 +23605,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 905:
-#line 5906 "tth.lex"
+#line 5908 "tth.lex"
 case 906:
 YY_RULE_SETUP
-#line 5906 "tth.lex"
+#line 5908 "tth.lex"
 {
   if(eqdepth){
     TTH_CCPY(tth_font_open[tth_push_depth],TTH_ITALO);
@@ -23620,10 +23622,10 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 907:
-#line 5918 "tth.lex"
+#line 5920 "tth.lex"
 case 908:
 YY_RULE_SETUP
-#line 5918 "tth.lex"
+#line 5920 "tth.lex"
 {
   if(eqdepth){
     TTH_CCPY(tth_font_open[tth_push_depth],TTH_TTO);
@@ -23637,16 +23639,16 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 909:
-#line 5930 "tth.lex"
-case 910:
-#line 5931 "tth.lex"
-case 911:
 #line 5932 "tth.lex"
-case 912:
+case 910:
 #line 5933 "tth.lex"
+case 911:
+#line 5934 "tth.lex"
+case 912:
+#line 5935 "tth.lex"
 case 913:
 YY_RULE_SETUP
-#line 5933 "tth.lex"
+#line 5935 "tth.lex"
 {
   if(eqdepth){
     TTH_CCPY(tth_font_open[tth_push_depth],TTH_NORM1);
@@ -23662,7 +23664,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 914:
 YY_RULE_SETUP
-#line 5945 "tth.lex"
+#line 5947 "tth.lex"
 { /* new approach */
   if(tth_push_depth){
     yy_push_state(textsc);
@@ -23673,13 +23675,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 915:
 YY_RULE_SETUP
-#line 5952 "tth.lex"
+#line 5954 "tth.lex"
 {
   TTH_OUTPUT(TTH_HELV1); TTH_PRECLOSE(TTH_HELV2);}
 	YY_BREAK
 case 916:
 YY_RULE_SETUP
-#line 5954 "tth.lex"
+#line 5956 "tth.lex"
 {
     TTH_CCAT(tth_font_open[tth_push_depth],TTH_BOLDO);
     TTH_CCAT(tth_font_close[tth_push_depth],TTH_BOLDC);
@@ -23687,7 +23689,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 917:
 YY_RULE_SETUP
-#line 5958 "tth.lex"
+#line 5960 "tth.lex"
 {
     TTH_CCPY(tth_font_open[tth_push_depth],tth_fonto_def);
     TTH_CCPY(tth_font_close[tth_push_depth],tth_fontc_def);
@@ -23695,12 +23697,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 918:
 YY_RULE_SETUP
-#line 5963 "tth.lex"
+#line 5965 "tth.lex"
 fprintf(tth_fdout,"<dl><dd>");TTH_PRECLOSE("</dd></dl>");
 	YY_BREAK
 case 919:
 YY_RULE_SETUP
-#line 5965 "tth.lex"
+#line 5967 "tth.lex"
 {
   fprintf(tth_fdout,"<dl><dd>");
   if(strstr(closing,"--vbox")){
@@ -23713,7 +23715,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 920:
 YY_RULE_SETUP
-#line 5974 "tth.lex"
+#line 5976 "tth.lex"
 {
   TTH_PUSH_CLOSING; fprintf(tth_fdout,"<dl><dd>");
   TTH_CCPY(closing,"</dd></dl>\n");
@@ -23722,7 +23724,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 921:
 YY_RULE_SETUP
-#line 5979 "tth.lex"
+#line 5981 "tth.lex"
 {
   fprintf(stderr,"Hangafter ignored\n");yy_push_state(lookfornum);*argchar=0;
 }
@@ -23732,45 +23734,45 @@ YY_RULE_SETUP
  Removed /{NUM} also in hangindent, 1.01 (also saved 10k size)*/
 case 922:
 YY_RULE_SETUP
-#line 5988 "tth.lex"
+#line 5990 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 923:
 YY_RULE_SETUP
-#line 5989 "tth.lex"
+#line 5991 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 /* Setting sizes: */
 case 924:
 YY_RULE_SETUP
-#line 5991 "tth.lex"
+#line 5993 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 925:
 YY_RULE_SETUP
-#line 5992 "tth.lex"
+#line 5994 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 926:
 YY_RULE_SETUP
-#line 5993 "tth.lex"
+#line 5995 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 927:
 YY_RULE_SETUP
-#line 5994 "tth.lex"
+#line 5996 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 928:
 YY_RULE_SETUP
-#line 5995 "tth.lex"
+#line 5997 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 /*<argclear>.|\n  yyless(0);yy_pop_state(); *argchar=0; */
 case 929:
 /* rule 929 can match eol */
 YY_RULE_SETUP
-#line 5999 "tth.lex"
+#line 6001 "tth.lex"
 {   /* Set a dimension that was defined. */
   strcpy(newcstr,yytext+1+strcspn(yytext+1,"\\"));
   *scratchstring=0;
@@ -23791,7 +23793,7 @@ YY_RULE_SETUP
 case 930:
 /* rule 930 can match eol */
 YY_RULE_SETUP
-#line 6015 "tth.lex"
+#line 6017 "tth.lex"
 {
   yy_pop_state();yyless(0);
   if(tth_debug&1024)fprintf(stderr,"Setdimen. scratchstring=%s, closing=%s, newcstr=%s, thesize=%d\n",scratchstring,closing,newcstr,thesize);
@@ -23821,7 +23823,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 931:
 YY_RULE_SETUP
-#line 6041 "tth.lex"
+#line 6043 "tth.lex"
 {
   TTH_DO_MACRO
     else{GET_DIMEN;}
@@ -23829,17 +23831,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 932:
 YY_RULE_SETUP
-#line 6045 "tth.lex"
+#line 6047 "tth.lex"
 TTH_TEX_FN("\\hskip #1{}#tthdrop1",1);
 	YY_BREAK
 case 933:
 YY_RULE_SETUP
-#line 6046 "tth.lex"
+#line 6048 "tth.lex"
 TTH_TEX_FN("\\vskip #1{}#tthdrop1",1);
 	YY_BREAK
 case 934:
 YY_RULE_SETUP
-#line 6047 "tth.lex"
+#line 6049 "tth.lex"
 {
   yy_push_state(hskip);
   yy_push_state(glue);GET_DIMEN;
@@ -23848,7 +23850,7 @@ YY_RULE_SETUP
 case 935:
 /* rule 935 can match eol */
 YY_RULE_SETUP
-#line 6051 "tth.lex"
+#line 6053 "tth.lex"
 {
   if(*scratchstring=='%'){ /* Size is in % of hsize. Guess 100 nbsp per line!*/
     for(js2=0;js2<thesize;js2++){TTH_OUTPUT("&nbsp;");}
@@ -23860,7 +23862,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 936:
 YY_RULE_SETUP
-#line 6059 "tth.lex"
+#line 6061 "tth.lex"
 {
   yy_push_state(vskip);
   yy_push_state(glue);GET_DIMEN;
@@ -23869,17 +23871,17 @@ YY_RULE_SETUP
 case 937:
 /* rule 937 can match eol */
 YY_RULE_SETUP
-#line 6063 "tth.lex"
+#line 6065 "tth.lex"
 {  /*Guess that <br /> is 14 pixels */
   for(js2=0;js2<(thesize/(SCALEDPERPIXEL*14));js2++){TTH_OUTPUT("<br />");}
   yy_pop_state(); yyless(0);
 }
 	YY_BREAK
 case 938:
-#line 6068 "tth.lex"
+#line 6070 "tth.lex"
 case 939:
 YY_RULE_SETUP
-#line 6068 "tth.lex"
+#line 6070 "tth.lex"
 {
   TTH_DO_MACRO
   else{
@@ -23891,7 +23893,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 940:
 YY_RULE_SETUP
-#line 6076 "tth.lex"
+#line 6078 "tth.lex"
 {
   if(!horizmode || horizmode==3 ||  strstr(closing,"<!--hbox") || 
      strstr(tth_texclose[tth_push_depth-1],"tthhbclose")){
@@ -23916,7 +23918,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 941:
 YY_RULE_SETUP
-#line 6098 "tth.lex"
+#line 6100 "tth.lex"
 {
   if(tth_debug&1024)fprintf(stderr,"tthhbclose Stack_ptr=%d. Closing=%s\n",tth_stack_ptr,closing);
   yy_pop_state();
@@ -23927,7 +23929,7 @@ YY_RULE_SETUP
 case 942:
 /* rule 942 can match eol */
 YY_RULE_SETUP
-#line 6106 "tth.lex"
+#line 6108 "tth.lex"
 {
   if(tth_debug&1024)fprintf(stderr,"Starting vbox\n");
   yy_pop_state();
@@ -23972,12 +23974,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 943:
 YY_RULE_SETUP
-#line 6147 "tth.lex"
+#line 6149 "tth.lex"
 {TTH_SWAP("\\tth_hbox");}
 	YY_BREAK
 case 944:
 YY_RULE_SETUP
-#line 6148 "tth.lex"
+#line 6150 "tth.lex"
 {
   if(horizmode){
     TTH_CCAT(closing,"<!--hbox-->");
@@ -23989,7 +23991,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 945:
 YY_RULE_SETUP
-#line 6156 "tth.lex"
+#line 6158 "tth.lex"
 {
   yy_push_state(hbox);
   GET_DIMEN;
@@ -23997,13 +23999,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 946:
 YY_RULE_SETUP
-#line 6160 "tth.lex"
+#line 6162 "tth.lex"
 TTH_SCAN_STRING("\\par\\hbox to\\hsize ");
 	YY_BREAK
 case 947:
 /* rule 947 can match eol */
 YY_RULE_SETUP
-#line 6162 "tth.lex"
+#line 6164 "tth.lex"
 {
   if(strstr(yytext,"\\h")){
     strcpy(boxalign," align=\"right\"");
@@ -24035,17 +24037,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 948:
 YY_RULE_SETUP
-#line 6190 "tth.lex"
+#line 6192 "tth.lex"
 horizmode=2; /* fprintf(stderr,"Set Horizmode=2.\n"); */
 	YY_BREAK
 case 949:
 YY_RULE_SETUP
-#line 6191 "tth.lex"
+#line 6193 "tth.lex"
 horizmode=3;
 	YY_BREAK
 case 950:
 YY_RULE_SETUP
-#line 6193 "tth.lex"
+#line 6195 "tth.lex"
 {
   fprintf(stderr,
 	  "**** Error: Apparently unembraced h/vbox:%s, near line %d\n",
@@ -24057,7 +24059,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 951:
 YY_RULE_SETUP
-#line 6201 "tth.lex"
+#line 6203 "tth.lex"
 { /* expand a possible macro */
   TTH_DO_MACRO else{
   yyless(0);
@@ -24068,10 +24070,10 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 952:
-#line 6210 "tth.lex"
+#line 6212 "tth.lex"
 case 953:
 YY_RULE_SETUP
-#line 6210 "tth.lex"
+#line 6212 "tth.lex"
 {
   if(strstr(closing,"</td></tr></table>")){ 
     TTH_OUTPUT("</td><td align=\"right\">"); /* align=right a compromise. */
@@ -24081,11 +24083,11 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 954:
-#line 6218 "tth.lex"
+#line 6220 "tth.lex"
 case 955:
 /* rule 955 can match eol */
 YY_RULE_SETUP
-#line 6218 "tth.lex"
+#line 6220 "tth.lex"
 {
   TTH_INC_MULTI;
   if(*(yytext+1)=='f')boxborder=1;
@@ -24117,7 +24119,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 956:
 YY_RULE_SETUP
-#line 6247 "tth.lex"
+#line 6249 "tth.lex"
 {
   sscanf(yytext+7,"%d",&js2);
   js2++;
@@ -24128,7 +24130,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 957:
 YY_RULE_SETUP
-#line 6255 "tth.lex"
+#line 6257 "tth.lex"
 {
   yy_push_state(getbox); /* Get the box definition, then define */
   yy_push_state(getdef); /* Get the next cs and leave in defchar.*/
@@ -24137,7 +24139,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 958:
 YY_RULE_SETUP
-#line 6262 "tth.lex"
+#line 6264 "tth.lex"
 {
   TTH_CCPY(argchar,yytext);
   TTH_CCAT(argchar," ");
@@ -24151,18 +24153,18 @@ YY_RULE_SETUP
 case 959:
 /* rule 959 can match eol */
 YY_RULE_SETUP
-#line 6271 "tth.lex"
+#line 6273 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 960:
 YY_RULE_SETUP
-#line 6272 "tth.lex"
+#line 6274 "tth.lex"
 
 	YY_BREAK
 case 961:
 /* rule 961 can match eol */
 YY_RULE_SETUP
-#line 6273 "tth.lex"
+#line 6275 "tth.lex"
 {
   yyless(0);
   yy_pop_state();
@@ -24174,34 +24176,34 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 962:
-#line 6284 "tth.lex"
+#line 6286 "tth.lex"
 /*\\vbox{SP}+to	|*/
 case 963:
-#line 6286 "tth.lex"
+#line 6288 "tth.lex"
 case 964:
-#line 6287 "tth.lex"
+#line 6289 "tth.lex"
 case 965:
 YY_RULE_SETUP
-#line 6287 "tth.lex"
+#line 6289 "tth.lex"
 GET_DIMEN
 	YY_BREAK
 case 966:
 YY_RULE_SETUP
-#line 6288 "tth.lex"
+#line 6290 "tth.lex"
 TTH_TEX_FN_OPT("#tthdrop3",3,"");
 	YY_BREAK
 /* Looking constructs */
 case 967:
 YY_RULE_SETUP
-#line 6291 "tth.lex"
+#line 6293 "tth.lex"
 {TTH_PUSH_CLOSING;TTH_CCPY(closing,argchar);
 			argchar[0]=0;yy_pop_state();}
 	YY_BREAK
 case 968:
-#line 6294 "tth.lex"
+#line 6296 "tth.lex"
 case 969:
 YY_RULE_SETUP
-#line 6294 "tth.lex"
+#line 6296 "tth.lex"
 {
       strcpy(dupstore,"{");strcat(dupstore,yytext);strcat(dupstore,"}");
       TTH_SCAN_STRING(dupstore);
@@ -24209,13 +24211,13 @@ YY_RULE_SETUP
       }
 	YY_BREAK
 case 970:
-#line 6300 "tth.lex"
+#line 6302 "tth.lex"
 case 971:
-#line 6301 "tth.lex"
+#line 6303 "tth.lex"
 case 972:
 /* rule 972 can match eol */
 YY_RULE_SETUP
-#line 6301 "tth.lex"
+#line 6303 "tth.lex"
 { 
   /* Count braces, save text in dupstore */
   TTH_INC_MULTI;
@@ -24227,21 +24229,21 @@ YY_RULE_SETUP
 	YY_BREAK
 case 973:
 YY_RULE_SETUP
-#line 6309 "tth.lex"
+#line 6311 "tth.lex"
 yy_push_state(number);jscratch=0;
 	YY_BREAK
 case 974:
 YY_RULE_SETUP
-#line 6310 "tth.lex"
+#line 6312 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 /* Prevent an expanding state from expanding:
     \hsize, natbib cites in footnotes*/
 case 975:
-#line 6314 "tth.lex"
+#line 6316 "tth.lex"
 case 976:
 YY_RULE_SETUP
-#line 6314 "tth.lex"
+#line 6316 "tth.lex"
 {
   if(tth_debug&4)fprintf(stderr,"We don't expand:%s \n",yytext);
   strcat(defstore,yytext);strcpy(xpndstring," ");
@@ -24249,7 +24251,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 977:
 YY_RULE_SETUP
-#line 6318 "tth.lex"
+#line 6320 "tth.lex"
 {
   if(tth_debug&4)fprintf(stderr,"Attempt to expand:%s ",yytext);
   TTH_DO_MACRO
@@ -24263,7 +24265,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 978:
 YY_RULE_SETUP
-#line 6328 "tth.lex"
+#line 6330 "tth.lex"
 { /* tth pseudo commands are unexpandable. */
     strcat(defstore,yytext);
     /* strcpy(xpndstring," "); And no termination is needed. */
@@ -24271,19 +24273,19 @@ YY_RULE_SETUP
 	YY_BREAK
 case 979:
 YY_RULE_SETUP
-#line 6332 "tth.lex"
+#line 6334 "tth.lex"
 {
   strcat(defstore,yytext+9);    strcpy(xpndstring," "); 
 }
 	YY_BREAK
 case 980:
 YY_RULE_SETUP
-#line 6335 "tth.lex"
+#line 6337 "tth.lex"
 
 	YY_BREAK
 case 981:
 YY_RULE_SETUP
-#line 6337 "tth.lex"
+#line 6339 "tth.lex"
 {
   strcat(defstore,yytext);
   yy_pop_state();
@@ -24304,13 +24306,13 @@ YY_RULE_SETUP
      If it is not, then output the space denoting the end of previous macro*/
 case 982:
 YY_RULE_SETUP
-#line 6354 "tth.lex"
+#line 6356 "tth.lex"
 strcat(defstore,yytext);*xpndstring=0;
 	YY_BREAK
 case 983:
 /* rule 983 can match eol */
 YY_RULE_SETUP
-#line 6355 "tth.lex"
+#line 6357 "tth.lex"
 {
     if(strcspn(yytext,"\n")==0) TTH_INC_LINE;
   strcat(defstore,xpndstring);strcat(defstore,yytext);*xpndstring=0;
@@ -24318,17 +24320,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 984:
 YY_RULE_SETUP
-#line 6359 "tth.lex"
+#line 6361 "tth.lex"
 strcat(defstore,yytext); /* Ensure \\ doesn't escape. */
 	YY_BREAK
 case 985:
 YY_RULE_SETUP
-#line 6360 "tth.lex"
+#line 6362 "tth.lex"
 strcat(defstore,yytext); /* Don't count escaped { */
 	YY_BREAK
 case 986:
 YY_RULE_SETUP
-#line 6361 "tth.lex"
+#line 6363 "tth.lex"
 {
    if(tth_debug&16) fprintf(stderr,"Open brace in [e]def, count=%d\n",
 			    bracecount);
@@ -24337,12 +24339,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 987:
 YY_RULE_SETUP
-#line 6366 "tth.lex"
+#line 6368 "tth.lex"
 strcat(defstore,yytext);
 	YY_BREAK
 case 988:
 YY_RULE_SETUP
-#line 6367 "tth.lex"
+#line 6369 "tth.lex"
 {
   if(!bracecount){
     if(tth_debug&16) fprintf(stderr,"Close brace ending [e]def,count=%d\n",
@@ -24379,24 +24381,24 @@ YY_RULE_SETUP
 case 989:
 /* rule 989 can match eol */
 YY_RULE_SETUP
-#line 6399 "tth.lex"
+#line 6401 "tth.lex"
 TTH_INC_LINE;TTH_CHECK_LENGTH;strcat(defstore,yytext);
 	YY_BREAK
 case 990:
 /* rule 990 can match eol */
 YY_RULE_SETUP
-#line 6400 "tth.lex"
+#line 6402 "tth.lex"
 strcat(defstore,yytext);
 	YY_BREAK
 case 991:
 /* rule 991 can match eol */
 YY_RULE_SETUP
-#line 6402 "tth.lex"
+#line 6404 "tth.lex"
 TTH_INC_MULTI;  /*Necessary for roots to work etc.*/
 	YY_BREAK
 case 992:
 YY_RULE_SETUP
-#line 6403 "tth.lex"
+#line 6405 "tth.lex"
 {
   yyless(0);yy_pop_state();
   yy_push_state(macarg);yy_push_state(embracetok);yy_push_state(optag);
@@ -24405,7 +24407,7 @@ YY_RULE_SETUP
 case 993:
 /* rule 993 can match eol */
 YY_RULE_SETUP
-#line 6407 "tth.lex"
+#line 6409 "tth.lex"
 {
   yyless(0);yy_pop_state();
   sprintf(scratchstring,"#%d",jarg);
@@ -24439,7 +24441,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 994:
 YY_RULE_SETUP
-#line 6437 "tth.lex"
+#line 6439 "tth.lex"
 { /* Don't add space after verb */
   strcat(dupstore,yytext);
   *(dupstore+strlen(dupstore)-1)=0;
@@ -24447,10 +24449,10 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 995:
-#line 6443 "tth.lex"
+#line 6445 "tth.lex"
 case 996:
 YY_RULE_SETUP
-#line 6443 "tth.lex"
+#line 6445 "tth.lex"
 { 
   strcat(dupstore,yytext);
   strcpy(dupstore+strlen(dupstore)-1," ");
@@ -24459,17 +24461,17 @@ YY_RULE_SETUP
  }
 	YY_BREAK
 case 997:
-#line 6450 "tth.lex"
+#line 6452 "tth.lex"
 case 998:
 YY_RULE_SETUP
-#line 6450 "tth.lex"
+#line 6452 "tth.lex"
 bracecount++;strcat(dupstore,yytext);
 	YY_BREAK
 case 999:
-#line 6452 "tth.lex"
+#line 6454 "tth.lex"
 case 1000:
 YY_RULE_SETUP
-#line 6452 "tth.lex"
+#line 6454 "tth.lex"
 {
 	if(bracecount == 0){
 	  sprintf(argchar,"#%d",jarg);
@@ -24508,13 +24510,13 @@ YY_RULE_SETUP
         }
 	YY_BREAK
 case 1001:
-#line 6489 "tth.lex"
+#line 6491 "tth.lex"
 case 1002:
-#line 6490 "tth.lex"
+#line 6492 "tth.lex"
 case 1003:
 /* rule 1003 can match eol */
 YY_RULE_SETUP
-#line 6490 "tth.lex"
+#line 6492 "tth.lex"
 {
   /* Count down braces. Save, or complete.
     storetype=
@@ -24577,7 +24579,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1004:
 YY_RULE_SETUP
-#line 6549 "tth.lex"
+#line 6551 "tth.lex"
 {
   if(verbinput){ TTH_OUTPUT(yytext);} 
   else{
@@ -24588,12 +24590,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1005:
 YY_RULE_SETUP
-#line 6557 "tth.lex"
+#line 6559 "tth.lex"
 TTH_TEX_FN("\\tth_grabverbname#tthdrop1",1);
 	YY_BREAK
 case 1006:
 YY_RULE_SETUP
-#line 6558 "tth.lex"
+#line 6560 "tth.lex"
 { /* Set the name of verb environment */
   if((jscratch=indexkey("#1",margkeys,&margmax))!=-1){
     strcpy(tth_verbenviron,margs[jscratch]);
@@ -24611,7 +24613,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1007:
 YY_RULE_SETUP
-#line 6572 "tth.lex"
+#line 6574 "tth.lex"
 {/* Redefinable verbatim end command */
   if(verbinput){ TTH_OUTPUT(yytext);
   }else{
@@ -24636,24 +24638,24 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1008:
 YY_RULE_SETUP
-#line 6594 "tth.lex"
+#line 6596 "tth.lex"
 {
   verbinput=0;
   TTH_TEXCLOSE else{TTH_CLOSEGROUP;TTH_POP_CLOSING;yy_pop_state();}
 }
 	YY_BREAK
 case 1009:
-#line 6599 "tth.lex"
+#line 6601 "tth.lex"
 case 1010:
 YY_RULE_SETUP
-#line 6599 "tth.lex"
+#line 6601 "tth.lex"
 {  
   TTH_TEXCLOSE else{TTH_CLOSEGROUP;TTH_POP_CLOSING;yy_pop_state();}
 }
 	YY_BREAK
 case 1011:
 YY_RULE_SETUP
-#line 6602 "tth.lex"
+#line 6604 "tth.lex"
 {
   TTH_OUTPUT(yytext);TTH_PUSH_CLOSING;
   TTH_CCPY(closing,"}");
@@ -24663,7 +24665,7 @@ YY_RULE_SETUP
 case 1012:
 /* rule 1012 can match eol */
 YY_RULE_SETUP
-#line 6609 "tth.lex"
+#line 6611 "tth.lex"
 {
   TTH_INC_MULTI;
   yy_pop_state();
@@ -24679,7 +24681,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1013:
 YY_RULE_SETUP
-#line 6621 "tth.lex"
+#line 6623 "tth.lex"
 { /* The dimension is in \hsizes */
   thesize=100*anumber;
   strcpy(scratchstring,"%");
@@ -24690,12 +24692,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1014:
 YY_RULE_SETUP
-#line 6628 "tth.lex"
+#line 6630 "tth.lex"
 GET_DIMEN; /* Do nothing outside for now */
 	YY_BREAK
 case 1015:
 YY_RULE_SETUP
-#line 6629 "tth.lex"
+#line 6631 "tth.lex"
 { /* expand a possible macro */
   TTH_DO_MACRO else { /* pop state if uninterpretable */
     if(tth_debug&1024) fprintf(stderr,"Unknown dimension %s\n",yytext);
@@ -24706,12 +24708,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1016:
 YY_RULE_SETUP
-#line 6636 "tth.lex"
+#line 6638 "tth.lex"
 /* Rip this out of the way */
 	YY_BREAK
 case 1017:
 YY_RULE_SETUP
-#line 6637 "tth.lex"
+#line 6639 "tth.lex"
 {/* We find a number. Scale instead. Shouldn't be in TeX*/
   if(! sscanf(yytext,"%f",&bnumber) ){
     fprintf(stderr,"**** Uninterpreted scaled dimension value:%s\n",yytext);
@@ -24723,22 +24725,22 @@ YY_RULE_SETUP
 case 1018:
 /* rule 1018 can match eol */
 YY_RULE_SETUP
-#line 6645 "tth.lex"
+#line 6647 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 1019:
 YY_RULE_SETUP
-#line 6646 "tth.lex"
+#line 6648 "tth.lex"
 /* Ignore spaces */
 	YY_BREAK
 case 1020:
 YY_RULE_SETUP
-#line 6647 "tth.lex"
+#line 6649 "tth.lex"
 /* and equal signs */
 	YY_BREAK
 case 1021:
 YY_RULE_SETUP
-#line 6648 "tth.lex"
+#line 6650 "tth.lex"
 { /* If we find a number store it.*/
   TTH_CCAT(argchar,yytext);
   if(! sscanf(argchar,"%f",&anumber) ){
@@ -24751,13 +24753,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1022:
 YY_RULE_SETUP
-#line 6657 "tth.lex"
+#line 6659 "tth.lex"
 strcat(argchar,yytext);
 	YY_BREAK
 /* If this is an unknown token, pop extra lookforunit state too.*/
 case 1023:
 YY_RULE_SETUP
-#line 6659 "tth.lex"
+#line 6661 "tth.lex"
 {
   TTH_DO_MACRO
   else{ 
@@ -24771,47 +24773,47 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1024:
 YY_RULE_SETUP
-#line 6669 "tth.lex"
+#line 6671 "tth.lex"
 {
   fprintf(tth_fdout,"%s%s",yytext,argchar);yy_pop_state();}
 	YY_BREAK
 case 1025:
 /* rule 1025 can match eol */
 YY_RULE_SETUP
-#line 6671 "tth.lex"
+#line 6673 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 1026:
 YY_RULE_SETUP
-#line 6672 "tth.lex"
+#line 6674 "tth.lex"
 
 	YY_BREAK
 case 1027:
 YY_RULE_SETUP
-#line 6673 "tth.lex"
+#line 6675 "tth.lex"
 {TTH_CCPY(argchar,yytext);yy_pop_state();
 			if(tth_verb) fprintf(stderr,"File:%s",yytext);}
 	YY_BREAK
 case 1028:
 /* rule 1028 can match eol */
 YY_RULE_SETUP
-#line 6675 "tth.lex"
+#line 6677 "tth.lex"
 TTH_INC_MULTI;tthglue=1;GET_DIMEN  
 	YY_BREAK
 /* nested glue not allowed */
 case 1029:
 /* rule 1029 can match eol */
 YY_RULE_SETUP
-#line 6677 "tth.lex"
+#line 6679 "tth.lex"
 tthglue=0;yyless(0);yy_pop_state();
 	YY_BREAK
 case 1030:
-#line 6680 "tth.lex"
+#line 6682 "tth.lex"
 case 1031:
-#line 6681 "tth.lex"
+#line 6683 "tth.lex"
 case 1032:
 YY_RULE_SETUP
-#line 6681 "tth.lex"
+#line 6683 "tth.lex"
 { /* already embraced */
   strcat(dupstore,"{");
   TTH_SCAN_STRING(dupstore);
@@ -24822,21 +24824,21 @@ YY_RULE_SETUP
 case 1033:
 /* rule 1033 can match eol */
 YY_RULE_SETUP
-#line 6688 "tth.lex"
+#line 6690 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 1034:
 YY_RULE_SETUP
-#line 6689 "tth.lex"
+#line 6691 "tth.lex"
 
 	YY_BREAK
 case 1035:
-#line 6691 "tth.lex"
+#line 6693 "tth.lex"
 case 1036:
-#line 6692 "tth.lex"
+#line 6694 "tth.lex"
 case 1037:
 YY_RULE_SETUP
-#line 6692 "tth.lex"
+#line 6694 "tth.lex"
 { /* Enclose a bare token for using as argument.*/
       strcat(dupstore,"{");strcat(dupstore,yytext);strcat(dupstore,"}");
       TTH_SCAN_STRING(dupstore);
@@ -24845,10 +24847,10 @@ YY_RULE_SETUP
       }
 	YY_BREAK
 case 1038:
-#line 6699 "tth.lex"
+#line 6701 "tth.lex"
 case 1039:
 YY_RULE_SETUP
-#line 6699 "tth.lex"
+#line 6701 "tth.lex"
 {
   sprintf(scratchstring,"{%s",swapchar);
   TTH_SCAN_STRING(scratchstring);*swapchar=0;yy_pop_state();
@@ -24856,7 +24858,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1040:
 YY_RULE_SETUP
-#line 6703 "tth.lex"
+#line 6705 "tth.lex"
 {
   fprintf(stderr,"**** Error: swaparg fault:%s:%s:\n",swapchar,yytext);
   yy_pop_state();}
@@ -24865,13 +24867,13 @@ YY_RULE_SETUP
 case 1041:
 /* rule 1041 can match eol */
 YY_RULE_SETUP
-#line 6708 "tth.lex"
+#line 6710 "tth.lex"
 TTH_INC_LINE;
 	YY_BREAK
 case 1042:
 /* rule 1042 can match eol */
 YY_RULE_SETUP
-#line 6709 "tth.lex"
+#line 6711 "tth.lex"
 {
   TTH_INC_LINE;
   fprintf(tth_fdout,"%s",yytext);
@@ -24882,7 +24884,7 @@ YY_RULE_SETUP
 case 1043:
 /* rule 1043 can match eol */
 YY_RULE_SETUP
-#line 6715 "tth.lex"
+#line 6717 "tth.lex"
 { /* Final route for all cases once expanded. */
   TTH_INC_MULTI;
   if(strlen(expchar)){
@@ -24912,7 +24914,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1044:
 YY_RULE_SETUP
-#line 6742 "tth.lex"
+#line 6744 "tth.lex"
 {
   if(tth_debug&8) fprintf(stderr,
 		 "Nothing to expand in exptok[arg]. Rescan:{%s}\n",yytext);
@@ -24922,7 +24924,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1045:
 YY_RULE_SETUP
-#line 6748 "tth.lex"
+#line 6750 "tth.lex"
 { /* fix for _\| etc */
   if(tth_debug&8)fprintf(stderr,"Exptokarg, expanding:%s\n",yytext);
   TTH_DO_MACRO
@@ -24935,7 +24937,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1046:
 YY_RULE_SETUP
-#line 6758 "tth.lex"
+#line 6760 "tth.lex"
 {
   yyless(0);yy_pop_state();
   if(strlen(exptex)){TTH_SCAN_STRING(exptex); *exptex=0;}
@@ -24943,7 +24945,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1047:
 YY_RULE_SETUP
-#line 6762 "tth.lex"
+#line 6764 "tth.lex"
 { /* fix for _\| etc OUT for tokexp. */
   if(tth_debug&8)fprintf(stderr,"Tokexp, expanding:%s\n",yytext);
   TTH_DO_MACRO
@@ -24957,7 +24959,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1048:
 YY_RULE_SETUP
-#line 6773 "tth.lex"
+#line 6775 "tth.lex"
 {
   if(*halstring){ /* In a display table has to be a null inline*/
   }else{
@@ -24971,12 +24973,12 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 1049:
-#line 6786 "tth.lex"
+#line 6788 "tth.lex"
 case 1050:
-#line 6787 "tth.lex"
+#line 6789 "tth.lex"
 case 1051:
 YY_RULE_SETUP
-#line 6787 "tth.lex"
+#line 6789 "tth.lex"
 {
   if(tth_debug&2) 
     fprintf(stderr,"Starting textbox equation, line %d\n",tth_num_lines);
@@ -24990,14 +24992,14 @@ YY_RULE_SETUP
 	YY_BREAK
 /* $ Will be superceded by equation grab for non-null eqs */
 case 1052:
-#line 6799 "tth.lex"
-case 1053:
-#line 6800 "tth.lex"
-case 1054:
 #line 6801 "tth.lex"
+case 1053:
+#line 6802 "tth.lex"
+case 1054:
+#line 6803 "tth.lex"
 case 1055:
 YY_RULE_SETUP
-#line 6801 "tth.lex"
+#line 6803 "tth.lex"
 { 
   if(displaystyle) fprintf(stderr,"Starting displaystyle incorrect.\n");
   displaystyle=0;
@@ -25017,13 +25019,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1056:
 YY_RULE_SETUP
-#line 6818 "tth.lex"
+#line 6820 "tth.lex"
 
 	YY_BREAK
 case 1057:
 /* rule 1057 can match eol */
 YY_RULE_SETUP
-#line 6820 "tth.lex"
+#line 6822 "tth.lex"
 {
   if(strcspn(yytext,"_^")==1){
     if(tth_debug&3) fprintf(stderr,"Special In line Eq:%s\n",yytext);
@@ -25050,11 +25052,11 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1058:
 /* rule 1058 can match eol */
-#line 6845 "tth.lex"
+#line 6847 "tth.lex"
 case 1059:
 /* rule 1059 can match eol */
 YY_RULE_SETUP
-#line 6845 "tth.lex"
+#line 6847 "tth.lex"
 { 
   if(tth_debug&33)fprintf(stderr,"Display Table:\n%s\n",yytext);
   fprintf(tth_fdout,"<dl><dd>");
@@ -25069,7 +25071,7 @@ YY_RULE_SETUP
     Does not permit non-output commands before the halign. TeX does.*/
 case 1060:
 YY_RULE_SETUP
-#line 6856 "tth.lex"
+#line 6858 "tth.lex"
 {
   yy_push_state(halsearch);
 }
@@ -25077,12 +25079,12 @@ YY_RULE_SETUP
 case 1061:
 /* rule 1061 can match eol */
 YY_RULE_SETUP
-#line 6860 "tth.lex"
+#line 6862 "tth.lex"
 TTH_INC_MULTI;
 	YY_BREAK
 case 1062:
 YY_RULE_SETUP
-#line 6861 "tth.lex"
+#line 6863 "tth.lex"
 {
   if(tth_debug&33)fprintf(stderr,"Display Table:\n%s\n",yytext);
   yyless(0);
@@ -25096,7 +25098,7 @@ YY_RULE_SETUP
 case 1063:
 /* rule 1063 can match eol */
 YY_RULE_SETUP
-#line 6870 "tth.lex"
+#line 6872 "tth.lex"
 {
   yyless(0);
   yy_pop_state();
@@ -25105,11 +25107,11 @@ YY_RULE_SETUP
 	YY_BREAK
 /* Don't recognize display equations except in certain allowed states. */
 case 1064:
-#line 6878 "tth.lex"
+#line 6880 "tth.lex"
 case 1065:
 /* rule 1065 can match eol */
 YY_RULE_SETUP
-#line 6878 "tth.lex"
+#line 6880 "tth.lex"
 {
   {
     if(tth_debug&3) fprintf(stderr,"Display Eq:\n%s\n",yytext);
@@ -25140,13 +25142,13 @@ YY_RULE_SETUP
 /* Translate single characters. */
 case 1066:
 YY_RULE_SETUP
-#line 6906 "tth.lex"
+#line 6908 "tth.lex"
 TTH_OUTPUTH(yytext+strlen(yytext)-1);
 	YY_BREAK
 case 1067:
 /* rule 1067 can match eol */
 YY_RULE_SETUP
-#line 6908 "tth.lex"
+#line 6910 "tth.lex"
 {
   TTH_INC_MULTI;
   sscanf(yytext+5,"%d",&jscratch);
@@ -25158,7 +25160,7 @@ YY_RULE_SETUP
 /* Latin Characters and other non-math but output correctly in math.*/
 case 1068:
 YY_RULE_SETUP
-#line 6917 "tth.lex"
+#line 6919 "tth.lex"
 { /* Circumvent spaces after accents.*/
   strcpy(scratchstring,yytext);
   unput(*(scratchstring+strlen(scratchstring)-1));
@@ -25166,556 +25168,556 @@ YY_RULE_SETUP
 }
 	YY_BREAK
 case 1069:
-#line 6924 "tth.lex"
+#line 6926 "tth.lex"
 case 1070:
-#line 6925 "tth.lex"
+#line 6927 "tth.lex"
 case 1071:
 YY_RULE_SETUP
-#line 6925 "tth.lex"
+#line 6927 "tth.lex"
 TTH_OUTPUTH("&nbsp;");
 	YY_BREAK
 case 1072:
 /* rule 1072 can match eol */
 YY_RULE_SETUP
-#line 6926 "tth.lex"
+#line 6928 "tth.lex"
 TTH_OUTPUTH("&nbsp;");TTH_INC_LINE;
 	YY_BREAK
 case 1073:
 YY_RULE_SETUP
-#line 6927 "tth.lex"
+#line 6929 "tth.lex"
 TTH_OUTPUTH("&nbsp;&nbsp;");
 	YY_BREAK
 case 1074:
 YY_RULE_SETUP
-#line 6928 "tth.lex"
+#line 6930 "tth.lex"
 TTH_OUTPUTH("&nbsp;&nbsp;&nbsp;");
 	YY_BREAK
 case 1075:
 YY_RULE_SETUP
-#line 6929 "tth.lex"
+#line 6931 "tth.lex"
 TTH_OUTPUTH("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
 	YY_BREAK
 case 1076:
 YY_RULE_SETUP
-#line 6930 "tth.lex"
+#line 6932 "tth.lex"
 TTH_OUTPUTH("&#198;");
 	YY_BREAK
 case 1077:
 YY_RULE_SETUP
-#line 6931 "tth.lex"
+#line 6933 "tth.lex"
 TTH_OUTPUTH("&#193;");
 	YY_BREAK
 case 1078:
 YY_RULE_SETUP
-#line 6932 "tth.lex"
+#line 6934 "tth.lex"
 TTH_OUTPUTH("&#194;");
 	YY_BREAK
 case 1079:
 YY_RULE_SETUP
-#line 6933 "tth.lex"
+#line 6935 "tth.lex"
 TTH_OUTPUTH("&#192;");
 	YY_BREAK
 case 1080:
-#line 6935 "tth.lex"
+#line 6937 "tth.lex"
 case 1081:
 YY_RULE_SETUP
-#line 6935 "tth.lex"
+#line 6937 "tth.lex"
 TTH_OUTPUTH("&#197;");
 	YY_BREAK
 case 1082:
 YY_RULE_SETUP
-#line 6936 "tth.lex"
+#line 6938 "tth.lex"
 TTH_OUTPUTH("&#195;");
 	YY_BREAK
 case 1083:
-#line 6938 "tth.lex"
+#line 6940 "tth.lex"
 case 1084:
 YY_RULE_SETUP
-#line 6938 "tth.lex"
+#line 6940 "tth.lex"
 TTH_OUTPUTH("&#196;");
 	YY_BREAK
 /*  \\c{SP}?C    | */
 case 1085:
 YY_RULE_SETUP
-#line 6940 "tth.lex"
+#line 6942 "tth.lex"
 TTH_OUTPUTH("&#199;");
 	YY_BREAK
 case 1086:
 YY_RULE_SETUP
-#line 6941 "tth.lex"
+#line 6943 "tth.lex"
 TTH_OUTPUTH("&#201;");
 	YY_BREAK
 case 1087:
 YY_RULE_SETUP
-#line 6942 "tth.lex"
+#line 6944 "tth.lex"
 TTH_OUTPUTH("&#202;");
 	YY_BREAK
 case 1088:
 YY_RULE_SETUP
-#line 6943 "tth.lex"
+#line 6945 "tth.lex"
 TTH_OUTPUTH("&#200;");
 	YY_BREAK
 case 1089:
-#line 6945 "tth.lex"
+#line 6947 "tth.lex"
 case 1090:
 YY_RULE_SETUP
-#line 6945 "tth.lex"
+#line 6947 "tth.lex"
 TTH_OUTPUTH("&#203;");
 	YY_BREAK
 case 1091:
 YY_RULE_SETUP
-#line 6946 "tth.lex"
+#line 6948 "tth.lex"
 TTH_OUTPUTH("&#204;");
 	YY_BREAK
 case 1092:
 YY_RULE_SETUP
-#line 6947 "tth.lex"
+#line 6949 "tth.lex"
 TTH_OUTPUTH("&#205;");
 	YY_BREAK
 case 1093:
 YY_RULE_SETUP
-#line 6948 "tth.lex"
+#line 6950 "tth.lex"
 TTH_OUTPUTH("&#206;");
 	YY_BREAK
 case 1094:
-#line 6950 "tth.lex"
+#line 6952 "tth.lex"
 case 1095:
 YY_RULE_SETUP
-#line 6950 "tth.lex"
+#line 6952 "tth.lex"
 TTH_OUTPUTH("&#207;");
 	YY_BREAK
 case 1096:
 YY_RULE_SETUP
-#line 6951 "tth.lex"
+#line 6953 "tth.lex"
 TTH_OUTPUTH("&#209;");
 	YY_BREAK
 case 1097:
 YY_RULE_SETUP
-#line 6952 "tth.lex"
+#line 6954 "tth.lex"
 TTH_OUTPUTH("&#210;");
 	YY_BREAK
 case 1098:
 YY_RULE_SETUP
-#line 6953 "tth.lex"
+#line 6955 "tth.lex"
 TTH_OUTPUTH("&#211;");
 	YY_BREAK
 case 1099:
 YY_RULE_SETUP
-#line 6954 "tth.lex"
+#line 6956 "tth.lex"
 TTH_OUTPUTH("&#212;");
 	YY_BREAK
 case 1100:
 YY_RULE_SETUP
-#line 6955 "tth.lex"
+#line 6957 "tth.lex"
 TTH_OUTPUTH("&#216;");
 	YY_BREAK
 case 1101:
 YY_RULE_SETUP
-#line 6956 "tth.lex"
+#line 6958 "tth.lex"
 TTH_OUTPUTH("&#213;");
 	YY_BREAK
 case 1102:
-#line 6958 "tth.lex"
+#line 6960 "tth.lex"
 case 1103:
 YY_RULE_SETUP
-#line 6958 "tth.lex"
+#line 6960 "tth.lex"
 TTH_OUTPUTH("&#214;");
 	YY_BREAK
 case 1104:
 YY_RULE_SETUP
-#line 6959 "tth.lex"
+#line 6961 "tth.lex"
 TTH_OUTPUTH("&#182;");
 	YY_BREAK
 case 1105:
 YY_RULE_SETUP
-#line 6960 "tth.lex"
+#line 6962 "tth.lex"
 TTH_OUTPUTH("&#167;");
 	YY_BREAK
 case 1106:
 YY_RULE_SETUP
-#line 6961 "tth.lex"
+#line 6963 "tth.lex"
 TTH_OUTPUTH("&#218;");
 	YY_BREAK
 case 1107:
 YY_RULE_SETUP
-#line 6962 "tth.lex"
+#line 6964 "tth.lex"
 TTH_OUTPUTH("&#219;");
 	YY_BREAK
 case 1108:
 YY_RULE_SETUP
-#line 6963 "tth.lex"
+#line 6965 "tth.lex"
 TTH_OUTPUTH("&#217;");
 	YY_BREAK
 case 1109:
-#line 6965 "tth.lex"
+#line 6967 "tth.lex"
 case 1110:
 YY_RULE_SETUP
-#line 6965 "tth.lex"
+#line 6967 "tth.lex"
 TTH_OUTPUTH("&#220;");
 	YY_BREAK
 case 1111:
 YY_RULE_SETUP
-#line 6966 "tth.lex"
+#line 6968 "tth.lex"
 TTH_OUTPUTH("&#221;");
 	YY_BREAK
 case 1112:
 YY_RULE_SETUP
-#line 6967 "tth.lex"
+#line 6969 "tth.lex"
 TTH_OUTPUTH("&amp;");
 	YY_BREAK
 case 1113:
 YY_RULE_SETUP
-#line 6968 "tth.lex"
+#line 6970 "tth.lex"
 TTH_OUTPUTH("&amp;");
 	YY_BREAK
 case 1114:
 YY_RULE_SETUP
-#line 6969 "tth.lex"
+#line 6971 "tth.lex"
 TTH_OUTPUTH("&#230;");
 	YY_BREAK
 case 1115:
 YY_RULE_SETUP
-#line 6970 "tth.lex"
+#line 6972 "tth.lex"
 TTH_OUTPUTH("&#224;");
 	YY_BREAK
 case 1116:
 YY_RULE_SETUP
-#line 6971 "tth.lex"
+#line 6973 "tth.lex"
 TTH_OUTPUTH("&#225;");
 	YY_BREAK
 case 1117:
 YY_RULE_SETUP
-#line 6972 "tth.lex"
+#line 6974 "tth.lex"
 TTH_OUTPUTH("&#226;");
 	YY_BREAK
 case 1118:
 YY_RULE_SETUP
-#line 6973 "tth.lex"
+#line 6975 "tth.lex"
 TTH_OUTPUTH("&#227;");
 	YY_BREAK
 case 1119:
-#line 6975 "tth.lex"
+#line 6977 "tth.lex"
 case 1120:
 YY_RULE_SETUP
-#line 6975 "tth.lex"
+#line 6977 "tth.lex"
 TTH_OUTPUTH("&#228;");
 	YY_BREAK
 case 1121:
-#line 6977 "tth.lex"
+#line 6979 "tth.lex"
 case 1122:
 YY_RULE_SETUP
-#line 6977 "tth.lex"
+#line 6979 "tth.lex"
 TTH_OUTPUTH("&#229;");
 	YY_BREAK
 /*  \\c{SP}?c              | */
 case 1123:
 YY_RULE_SETUP
-#line 6979 "tth.lex"
+#line 6981 "tth.lex"
 TTH_OUTPUTH("&#231;");
 	YY_BREAK
 case 1124:
 YY_RULE_SETUP
-#line 6980 "tth.lex"
+#line 6982 "tth.lex"
 TTH_OUTPUTH("^");
 	YY_BREAK
 case 1125:
 YY_RULE_SETUP
-#line 6981 "tth.lex"
+#line 6983 "tth.lex"
 TTH_OUTPUTH("&#169;");
 	YY_BREAK
 case 1126:
 YY_RULE_SETUP
-#line 6982 "tth.lex"
+#line 6984 "tth.lex"
 TTH_OUTPUTH("&#233;");
 	YY_BREAK
 case 1127:
 YY_RULE_SETUP
-#line 6983 "tth.lex"
+#line 6985 "tth.lex"
 TTH_OUTPUTH("&#234;");
 	YY_BREAK
 case 1128:
 YY_RULE_SETUP
-#line 6984 "tth.lex"
+#line 6986 "tth.lex"
 TTH_OUTPUTH("&#232;");
 	YY_BREAK
 case 1129:
 YY_RULE_SETUP
-#line 6985 "tth.lex"
+#line 6987 "tth.lex"
 TTH_OUTPUTH("&#240;");
 	YY_BREAK
 case 1130:
-#line 6987 "tth.lex"
+#line 6989 "tth.lex"
 case 1131:
 YY_RULE_SETUP
-#line 6987 "tth.lex"
+#line 6989 "tth.lex"
 TTH_OUTPUTH("&#235;");
 	YY_BREAK
 case 1132:
-#line 6989 "tth.lex"
+#line 6991 "tth.lex"
 case 1133:
 YY_RULE_SETUP
-#line 6989 "tth.lex"
+#line 6991 "tth.lex"
 TTH_OUTPUTH("&#62;");
 	YY_BREAK
 case 1134:
-#line 6991 "tth.lex"
+#line 6993 "tth.lex"
 case 1135:
 YY_RULE_SETUP
-#line 6991 "tth.lex"
+#line 6993 "tth.lex"
 TTH_OUTPUTH("&lt;");
 	YY_BREAK
 case 1136:
 YY_RULE_SETUP
-#line 6992 "tth.lex"
+#line 6994 "tth.lex"
 TTH_OUTPUTH("&nbsp;")
 	YY_BREAK
 case 1137:
-#line 6994 "tth.lex"
+#line 6996 "tth.lex"
 case 1138:
 YY_RULE_SETUP
-#line 6994 "tth.lex"
+#line 6996 "tth.lex"
 TTH_OUTPUTH("&#236;");
 	YY_BREAK
 case 1139:
-#line 6996 "tth.lex"
+#line 6998 "tth.lex"
 case 1140:
-#line 6997 "tth.lex"
+#line 6999 "tth.lex"
 case 1141:
 YY_RULE_SETUP
-#line 6997 "tth.lex"
+#line 6999 "tth.lex"
 TTH_OUTPUTH("&#237;");
 	YY_BREAK
 case 1142:
-#line 6999 "tth.lex"
+#line 7001 "tth.lex"
 case 1143:
 YY_RULE_SETUP
-#line 6999 "tth.lex"
+#line 7001 "tth.lex"
 TTH_OUTPUTH("&#238;");
 	YY_BREAK
 case 1144:
-#line 7001 "tth.lex"
+#line 7003 "tth.lex"
 case 1145:
-#line 7002 "tth.lex"
+#line 7004 "tth.lex"
 case 1146:
 YY_RULE_SETUP
-#line 7002 "tth.lex"
+#line 7004 "tth.lex"
 TTH_OUTPUTH("&#239;");
 	YY_BREAK
 case 1147:
 YY_RULE_SETUP
-#line 7003 "tth.lex"
+#line 7005 "tth.lex"
 TTH_OUTPUTH("&#241;");
 	YY_BREAK
 case 1148:
 YY_RULE_SETUP
-#line 7004 "tth.lex"
+#line 7006 "tth.lex"
 TTH_OUTPUTH("&#242;");
 	YY_BREAK
 case 1149:
 YY_RULE_SETUP
-#line 7005 "tth.lex"
+#line 7007 "tth.lex"
 TTH_OUTPUTH("&#243;");
 	YY_BREAK
 case 1150:
 YY_RULE_SETUP
-#line 7006 "tth.lex"
+#line 7008 "tth.lex"
 TTH_OUTPUTH("&#244;");
 	YY_BREAK
 case 1151:
 YY_RULE_SETUP
-#line 7007 "tth.lex"
+#line 7009 "tth.lex"
 TTH_OUTPUTH("&#248;");
 	YY_BREAK
 case 1152:
 YY_RULE_SETUP
-#line 7008 "tth.lex"
+#line 7010 "tth.lex"
 TTH_OUTPUTH("&#245;");
 	YY_BREAK
 case 1153:
-#line 7010 "tth.lex"
+#line 7012 "tth.lex"
 case 1154:
 YY_RULE_SETUP
-#line 7010 "tth.lex"
+#line 7012 "tth.lex"
 TTH_OUTPUTH("&#246;");
 	YY_BREAK
 case 1155:
 YY_RULE_SETUP
-#line 7011 "tth.lex"
+#line 7013 "tth.lex"
 TTH_OUTPUTH("&#175;");
 	YY_BREAK
 case 1156:
 YY_RULE_SETUP
-#line 7012 "tth.lex"
+#line 7014 "tth.lex"
 TTH_OUTPUTH("&#163;");
 	YY_BREAK
 case 1157:
 YY_RULE_SETUP
-#line 7013 "tth.lex"
+#line 7015 "tth.lex"
 TTH_OUTPUTH("&#126;");
 	YY_BREAK
 case 1158:
 YY_RULE_SETUP
-#line 7014 "tth.lex"
+#line 7016 "tth.lex"
 TTH_OUTPUTH("&#250;");
 	YY_BREAK
 case 1159:
 YY_RULE_SETUP
-#line 7015 "tth.lex"
+#line 7017 "tth.lex"
 TTH_OUTPUTH("&#251;");
 	YY_BREAK
 case 1160:
 YY_RULE_SETUP
-#line 7016 "tth.lex"
+#line 7018 "tth.lex"
 TTH_OUTPUTH("&#249;");
 	YY_BREAK
 case 1161:
-#line 7018 "tth.lex"
+#line 7020 "tth.lex"
 case 1162:
 YY_RULE_SETUP
-#line 7018 "tth.lex"
+#line 7020 "tth.lex"
 TTH_OUTPUTH("&#252;");
 	YY_BREAK
 case 1163:
 YY_RULE_SETUP
-#line 7019 "tth.lex"
+#line 7021 "tth.lex"
 TTH_OUTPUTH("&#253;");
 	YY_BREAK
 case 1164:
-#line 7021 "tth.lex"
+#line 7023 "tth.lex"
 case 1165:
 YY_RULE_SETUP
-#line 7021 "tth.lex"
+#line 7023 "tth.lex"
 TTH_OUTPUTH("&#255;");
 	YY_BREAK
 case 1166:
 YY_RULE_SETUP
-#line 7022 "tth.lex"
+#line 7024 "tth.lex"
 TTH_OUTPUTH("&#223;");
 	YY_BREAK
 case 1167:
-#line 7024 "tth.lex"
+#line 7026 "tth.lex"
 case 1168:
 YY_RULE_SETUP
-#line 7024 "tth.lex"
+#line 7026 "tth.lex"
 TTH_DO_MACRO else{ TTH_OUTPUTH("&#223;");}
 	YY_BREAK
 /* Polish character macros:*/
 case 1169:
 YY_RULE_SETUP
-#line 7026 "tth.lex"
+#line 7028 "tth.lex"
 TTH_OUTPUTH("&#260;");
 	YY_BREAK
 case 1170:
 YY_RULE_SETUP
-#line 7027 "tth.lex"
+#line 7029 "tth.lex"
 TTH_OUTPUTH("&#262;");
 	YY_BREAK
 case 1171:
 YY_RULE_SETUP
-#line 7028 "tth.lex"
+#line 7030 "tth.lex"
 TTH_OUTPUTH("&#280;");
 	YY_BREAK
 case 1172:
 YY_RULE_SETUP
-#line 7029 "tth.lex"
+#line 7031 "tth.lex"
 TTH_OUTPUTH("&#321;");
 	YY_BREAK
 case 1173:
 YY_RULE_SETUP
-#line 7030 "tth.lex"
+#line 7032 "tth.lex"
 TTH_OUTPUTH("&#323;");
 	YY_BREAK
 case 1174:
 YY_RULE_SETUP
-#line 7031 "tth.lex"
+#line 7033 "tth.lex"
 TTH_OUTPUTH("&#346;");
 	YY_BREAK
 case 1175:
 YY_RULE_SETUP
-#line 7032 "tth.lex"
+#line 7034 "tth.lex"
 TTH_OUTPUTH("&#377;");
 	YY_BREAK
 case 1176:
 YY_RULE_SETUP
-#line 7033 "tth.lex"
+#line 7035 "tth.lex"
 TTH_OUTPUTH("&#379;");
 	YY_BREAK
 case 1177:
 YY_RULE_SETUP
-#line 7034 "tth.lex"
+#line 7036 "tth.lex"
 TTH_OUTPUTH("&#261;");
 	YY_BREAK
 case 1178:
 YY_RULE_SETUP
-#line 7035 "tth.lex"
+#line 7037 "tth.lex"
 TTH_OUTPUTH("&#263;");
 	YY_BREAK
 case 1179:
 YY_RULE_SETUP
-#line 7036 "tth.lex"
+#line 7038 "tth.lex"
 TTH_OUTPUTH("&#281;");
 	YY_BREAK
 case 1180:
 YY_RULE_SETUP
-#line 7037 "tth.lex"
+#line 7039 "tth.lex"
 TTH_OUTPUTH("&#322;");
 	YY_BREAK
 case 1181:
 YY_RULE_SETUP
-#line 7038 "tth.lex"
+#line 7040 "tth.lex"
 TTH_OUTPUTH("&#324;");
 	YY_BREAK
 case 1182:
 YY_RULE_SETUP
-#line 7039 "tth.lex"
+#line 7041 "tth.lex"
 TTH_OUTPUTH("&#347;");
 	YY_BREAK
 case 1183:
 YY_RULE_SETUP
-#line 7040 "tth.lex"
+#line 7042 "tth.lex"
 TTH_OUTPUTH("&#378;");
 	YY_BREAK
 case 1184:
 YY_RULE_SETUP
-#line 7041 "tth.lex"
+#line 7043 "tth.lex"
 TTH_OUTPUTH("&#380;");
 	YY_BREAK
 case 1185:
 YY_RULE_SETUP
-#line 7043 "tth.lex"
+#line 7045 "tth.lex"
 TTH_OUTPUTH(",,");
 	YY_BREAK
 case 1186:
 YY_RULE_SETUP
-#line 7044 "tth.lex"
+#line 7046 "tth.lex"
 TTH_OUTPUTH("''");
 	YY_BREAK
 case 1187:
 YY_RULE_SETUP
-#line 7045 "tth.lex"
+#line 7047 "tth.lex"
 TTH_OUTPUTH("&#171;");
 	YY_BREAK
 case 1188:
 YY_RULE_SETUP
-#line 7046 "tth.lex"
+#line 7048 "tth.lex"
 TTH_OUTPUTH("&#187;");
 	YY_BREAK
 case 1189:
 YY_RULE_SETUP
-#line 7047 "tth.lex"
+#line 7049 "tth.lex"
 
 	YY_BREAK
 /* Convert TeX double quotes to single-character */
 case 1190:
-#line 7050 "tth.lex"
+#line 7052 "tth.lex"
 case 1191:
 YY_RULE_SETUP
-#line 7050 "tth.lex"
+#line 7052 "tth.lex"
 TTH_OUTPUTH("\"");
 	YY_BREAK
 case 1192:
 YY_RULE_SETUP
-#line 7051 "tth.lex"
+#line 7053 "tth.lex"
 {
   if(*(yytext+1)=='g') strcpy(scratchstring,"\\`");
   else  strcpy(scratchstring,"\\'");
@@ -25725,11 +25727,11 @@ YY_RULE_SETUP
 	YY_BREAK
 /* Remove unwanted braces from around accented characters. */
 case 1193:
-#line 7059 "tth.lex"
+#line 7061 "tth.lex"
 /*  \\c{SP}*\{[cC]\}   | */
 case 1194:
 YY_RULE_SETUP
-#line 7060 "tth.lex"
+#line 7062 "tth.lex"
 {
   if(tth_debug&8) fprintf(stderr,"Fixing accent:%s\n",yytext);
   *dupstore2=0;
@@ -25746,32 +25748,32 @@ YY_RULE_SETUP
  Above are safely defined. Below need protection.*/
 case 1195:
 YY_RULE_SETUP
-#line 7073 "tth.lex"
+#line 7075 "tth.lex"
 
 	YY_BREAK
 case 1196:
 YY_RULE_SETUP
-#line 7074 "tth.lex"
+#line 7076 "tth.lex"
 
 	YY_BREAK
 case 1197:
 YY_RULE_SETUP
-#line 7075 "tth.lex"
+#line 7077 "tth.lex"
 
 	YY_BREAK
 case 1198:
 YY_RULE_SETUP
-#line 7076 "tth.lex"
+#line 7078 "tth.lex"
 
 	YY_BREAK
 case 1199:
 YY_RULE_SETUP
-#line 7078 "tth.lex"
+#line 7080 "tth.lex"
 TTH_OUTPUTH(TTH_BOXCODE);
 	YY_BREAK
 case 1200:
 YY_RULE_SETUP
-#line 7079 "tth.lex"
+#line 7081 "tth.lex"
 TTH_OUTPUTH(TTH_HBAR);
 	YY_BREAK
 /* Various things not being used.
@@ -25781,7 +25783,7 @@ TTH_OUTPUTH(TTH_HBAR);
  */
 case 1201:
 YY_RULE_SETUP
-#line 7086 "tth.lex"
+#line 7088 "tth.lex"
 {
   TTH_SCAN_STRING(tth_latex_file);
 }
@@ -25789,25 +25791,25 @@ YY_RULE_SETUP
 /* This needs to match all the cases of comments otherwise they will
     not allow escaping of the % in that state. Not all are TTH_OUTPUT */
 case 1202:
-#line 7092 "tth.lex"
+#line 7094 "tth.lex"
 case 1203:
-#line 7093 "tth.lex"
+#line 7095 "tth.lex"
 case 1204:
 YY_RULE_SETUP
-#line 7093 "tth.lex"
+#line 7095 "tth.lex"
 TTH_OUTPUTH("%");
 	YY_BREAK
 case 1205:
 YY_RULE_SETUP
-#line 7094 "tth.lex"
+#line 7096 "tth.lex"
 
 	YY_BREAK
 case 1206:
-#line 7096 "tth.lex"
+#line 7098 "tth.lex"
 case 1207:
 /* rule 1207 can match eol */
 YY_RULE_SETUP
-#line 7096 "tth.lex"
+#line 7098 "tth.lex"
 {
   if(strcspn(yytext,"\n")==0) {TTH_INC_LINE;TTH_CHECK_LENGTH;}
   strcat(dupstore,yytext);
@@ -25815,30 +25817,30 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1208:
 YY_RULE_SETUP
-#line 7100 "tth.lex"
+#line 7102 "tth.lex"
 strcat(defstore,yytext); 
 	YY_BREAK
 case 1209:
 /* rule 1209 can match eol */
 YY_RULE_SETUP
-#line 7101 "tth.lex"
+#line 7103 "tth.lex"
 {
   TTH_INC_LINE;
 }
 	YY_BREAK
 case 1210:
-#line 7105 "tth.lex"
+#line 7107 "tth.lex"
 case 1211:
-#line 7106 "tth.lex"
+#line 7108 "tth.lex"
 /* \\\\\*?({SP}*\[[^\]]*\])?         | */
 case 1212:
 YY_RULE_SETUP
-#line 7107 "tth.lex"
+#line 7109 "tth.lex"
 TTH_SCAN_STRING("\\par");
 	YY_BREAK
 case 1213:
 YY_RULE_SETUP
-#line 7108 "tth.lex"
+#line 7110 "tth.lex"
 {
   if(horizmode) horizmode=1;
   jscratch=indexkey("#1",margkeys,&margmax);
@@ -25855,70 +25857,70 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1214:
 YY_RULE_SETUP
-#line 7122 "tth.lex"
+#line 7124 "tth.lex"
 TTH_OUTPUTH("$");
 	YY_BREAK
 case 1215:
 YY_RULE_SETUP
-#line 7123 "tth.lex"
+#line 7125 "tth.lex"
 TTH_OUTPUTH("#");
 	YY_BREAK
 case 1216:
 YY_RULE_SETUP
-#line 7124 "tth.lex"
+#line 7126 "tth.lex"
 TTH_OUTPUTH("{");
 	YY_BREAK
 case 1217:
 YY_RULE_SETUP
-#line 7125 "tth.lex"
+#line 7127 "tth.lex"
 TTH_OUTPUTH("}");
 	YY_BREAK
 /* In nbsp choice above \\{SP}			TTH_OUTPUTH(" "); */
 case 1218:
 YY_RULE_SETUP
-#line 7127 "tth.lex"
+#line 7129 "tth.lex"
 TTH_OUTPUTH("_");
 	YY_BREAK
 case 1219:
 YY_RULE_SETUP
-#line 7128 "tth.lex"
+#line 7130 "tth.lex"
 
 	YY_BREAK
 case 1220:
 YY_RULE_SETUP
-#line 7129 "tth.lex"
+#line 7131 "tth.lex"
 TTH_OUTPUTH(" ");
 	YY_BREAK
 case 1221:
 YY_RULE_SETUP
-#line 7130 "tth.lex"
+#line 7132 "tth.lex"
 TTH_OUTPUTH("-");
 	YY_BREAK
 case 1222:
 YY_RULE_SETUP
-#line 7131 "tth.lex"
+#line 7133 "tth.lex"
 TTH_OUTPUTH("..."); /* non-math dots */
 	YY_BREAK
 /* Commands to ignore in equations as well as text*/
 case 1223:
 YY_RULE_SETUP
-#line 7133 "tth.lex"
+#line 7135 "tth.lex"
 
 	YY_BREAK
 case 1224:
 YY_RULE_SETUP
-#line 7134 "tth.lex"
+#line 7136 "tth.lex"
 
 	YY_BREAK
 case 1225:
 YY_RULE_SETUP
-#line 7135 "tth.lex"
+#line 7137 "tth.lex"
 
 	YY_BREAK
 /* Some problems in equations being confused with this, unless specific. */
 case 1226:
 YY_RULE_SETUP
-#line 7138 "tth.lex"
+#line 7140 "tth.lex"
 {
   fprintf(stderr,"**** Removing inappropriate parameter command %s Line %d\n",yytext,tth_num_lines);
   yy_push_state(lookfornum);*argchar=0;
@@ -25926,13 +25928,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1227:
 YY_RULE_SETUP
-#line 7142 "tth.lex"
+#line 7144 "tth.lex"
 /* Overridden where necessary for defs.. */
 	YY_BREAK
 /* TeX Commands in equations*/
 case 1228:
 YY_RULE_SETUP
-#line 7145 "tth.lex"
+#line 7147 "tth.lex"
 {
   TTH_DO_MACRO
   else if( (ind=indexkey(yytext,countkeys,&ncounters)) != -1) { 
@@ -25949,20 +25951,20 @@ YY_RULE_SETUP
 /* Default equation action may no longer be needed, but not sure. 21 Mar*/
 case 1229:
 YY_RULE_SETUP
-#line 7158 "tth.lex"
+#line 7160 "tth.lex"
 {
   strcat(eqstr,yytext);
  }
 	YY_BREAK
 case 1230:
 YY_RULE_SETUP
-#line 7162 "tth.lex"
+#line 7164 "tth.lex"
 yy_scan_string("}\\end");
 	YY_BREAK
 /* Latex default (unknown) environment */
 case 1231:
 YY_RULE_SETUP
-#line 7164 "tth.lex"
+#line 7166 "tth.lex"
 {
   TTH_CCPY(environment,strstr(yytext,"{")+1);
   environment[strlen(environment)-1]=0;
@@ -25978,7 +25980,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1232:
 YY_RULE_SETUP
-#line 7176 "tth.lex"
+#line 7178 "tth.lex"
 {
   ind=indexkey(yytext,keys,&nkeys);
   TTH_SCAN_STRING("\\egroup");
@@ -25994,7 +25996,7 @@ YY_RULE_SETUP
 case 1233:
 /* rule 1233 can match eol */
 YY_RULE_SETUP
-#line 7187 "tth.lex"
+#line 7189 "tth.lex"
 {
   TTH_INC_MULTI;
   if(strstr(yytext,"\n")){TTH_INC_LINE;}
@@ -26006,7 +26008,7 @@ YY_RULE_SETUP
 case 1234:
 /* rule 1234 can match eol */
 YY_RULE_SETUP
-#line 7194 "tth.lex"
+#line 7196 "tth.lex"
 {
   TTH_INC_MULTI;
   if(strstr(yytext,"\n")){TTH_INC_LINE;}
@@ -26017,7 +26019,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1235:
 YY_RULE_SETUP
-#line 7202 "tth.lex"
+#line 7204 "tth.lex"
 {
   if(*yytext == *chr1){
     TTH_TEXCLOSE else{
@@ -26036,48 +26038,48 @@ YY_RULE_SETUP
 /* Special escape sequences in rawgroup */
 case 1236:
 YY_RULE_SETUP
-#line 7218 "tth.lex"
+#line 7220 "tth.lex"
 TTH_OUTPUT(yytext+1);
 	YY_BREAK
 /* Don't set horizmode for whitespace.*/
 case 1237:
 YY_RULE_SETUP
-#line 7220 "tth.lex"
+#line 7222 "tth.lex"
 TTH_OUTPUT(yytext);
 	YY_BREAK
 /* Default action */
 case 1238:
 YY_RULE_SETUP
-#line 7222 "tth.lex"
+#line 7224 "tth.lex"
 horizmode=1;TTH_OUTPUT(yytext);
 	YY_BREAK
 /* Normal action. Set to horizontal mode if not space*/
 case 1239:
 YY_RULE_SETUP
-#line 7224 "tth.lex"
+#line 7226 "tth.lex"
 fprintf(tth_fdout,"%s",yytext);
 	YY_BREAK
 /* Default action */
 case 1240:
 YY_RULE_SETUP
-#line 7226 "tth.lex"
+#line 7228 "tth.lex"
 horizmode=1;fprintf(tth_fdout,"%s",yytext);
 	YY_BREAK
 /* Delete in certain states. */
 case 1241:
 YY_RULE_SETUP
-#line 7229 "tth.lex"
+#line 7231 "tth.lex"
 yyless(0);yy_pop_state();      
 	YY_BREAK
 case 1242:
 YY_RULE_SETUP
-#line 7230 "tth.lex"
+#line 7232 "tth.lex"
 
 	YY_BREAK
 case 1243:
 /* rule 1243 can match eol */
 YY_RULE_SETUP
-#line 7232 "tth.lex"
+#line 7234 "tth.lex"
 {
   if(tth_ercnt==0){
     fprintf(stderr,"%s",yytext);
@@ -26089,99 +26091,99 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1244:
 YY_RULE_SETUP
-#line 7241 "tth.lex"
+#line 7243 "tth.lex"
 horizmode=1;
 	YY_BREAK
 case 1245:
 YY_RULE_SETUP
-#line 7242 "tth.lex"
+#line 7244 "tth.lex"
 {TTH_PAR_ACTION}
 	YY_BREAK
 case 1246:
 YY_RULE_SETUP
-#line 7243 "tth.lex"
+#line 7245 "tth.lex"
 yy_push_state(unknown);
 	YY_BREAK
 case 1247:
 YY_RULE_SETUP
-#line 7244 "tth.lex"
+#line 7246 "tth.lex"
 yy_push_state(unknown);
 	YY_BREAK
 case 1248:
 YY_RULE_SETUP
-#line 7245 "tth.lex"
+#line 7247 "tth.lex"
 fprintf(stderr,"**** DANGER: Catcode changes not honored. Expect abnormal behavior. Line %d\n",tth_num_lines);
 	YY_BREAK
 /* Ignore quietly */
 case 1249:
 YY_RULE_SETUP
-#line 7248 "tth.lex"
+#line 7250 "tth.lex"
 
 	YY_BREAK
 case 1250:
 YY_RULE_SETUP
-#line 7249 "tth.lex"
+#line 7251 "tth.lex"
 
 	YY_BREAK
 case 1251:
 YY_RULE_SETUP
-#line 7250 "tth.lex"
+#line 7252 "tth.lex"
 
 	YY_BREAK
 case 1252:
 YY_RULE_SETUP
-#line 7251 "tth.lex"
+#line 7253 "tth.lex"
 
 	YY_BREAK
 case 1253:
 YY_RULE_SETUP
-#line 7252 "tth.lex"
+#line 7254 "tth.lex"
 
 	YY_BREAK
 case 1254:
 YY_RULE_SETUP
-#line 7253 "tth.lex"
+#line 7255 "tth.lex"
 
 	YY_BREAK
 case 1255:
 YY_RULE_SETUP
-#line 7254 "tth.lex"
+#line 7256 "tth.lex"
 
 	YY_BREAK
 /*\\line   | */
 case 1256:
 YY_RULE_SETUP
-#line 7256 "tth.lex"
+#line 7258 "tth.lex"
 
 	YY_BREAK
 case 1257:
 YY_RULE_SETUP
-#line 7257 "tth.lex"
+#line 7259 "tth.lex"
 
 	YY_BREAK
 case 1258:
 YY_RULE_SETUP
-#line 7258 "tth.lex"
+#line 7260 "tth.lex"
 
 	YY_BREAK
 case 1259:
-#line 7260 "tth.lex"
+#line 7262 "tth.lex"
 case 1260:
-#line 7261 "tth.lex"
+#line 7263 "tth.lex"
 case 1261:
 YY_RULE_SETUP
-#line 7261 "tth.lex"
+#line 7263 "tth.lex"
 { /* Dump the argument. Might be used instead of matchbrace. */
   TTH_TEX_FN("#tthdrop1",1);
 }
 	YY_BREAK
 case 1262:
-#line 7265 "tth.lex"
+#line 7267 "tth.lex"
 case 1263:
-#line 7266 "tth.lex"
+#line 7268 "tth.lex"
 case 1264:
 YY_RULE_SETUP
-#line 7266 "tth.lex"
+#line 7268 "tth.lex"
 {
   sscanf(yytext+strcspn(yytext,"0123456789"),"%d", &js2);
   js2++;
@@ -26192,7 +26194,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1265:
 YY_RULE_SETUP
-#line 7274 "tth.lex"
+#line 7276 "tth.lex"
 {
   fprintf(stderr,"%s","\nUnusual bibdata command; if natbib not explicit,\n\
 maybe insert the following in the preamble:\n\
@@ -26202,71 +26204,71 @@ maybe insert the following in the preamble:\n\
 }
 	YY_BREAK
 case 1266:
-#line 7283 "tth.lex"
-case 1267:
-#line 7284 "tth.lex"
-case 1268:
 #line 7285 "tth.lex"
-case 1269:
+case 1267:
 #line 7286 "tth.lex"
-case 1270:
+case 1268:
 #line 7287 "tth.lex"
-case 1271:
+case 1269:
 #line 7288 "tth.lex"
-case 1272:
+case 1270:
 #line 7289 "tth.lex"
-case 1273:
+case 1271:
 #line 7290 "tth.lex"
+case 1272:
+#line 7291 "tth.lex"
+case 1273:
+#line 7292 "tth.lex"
 case 1274:
 /* rule 1274 can match eol */
-#line 7291 "tth.lex"
+#line 7293 "tth.lex"
 case 1275:
 /* rule 1275 can match eol */
-#line 7292 "tth.lex"
+#line 7294 "tth.lex"
 case 1276:
 /* rule 1276 can match eol */
-#line 7293 "tth.lex"
+#line 7295 "tth.lex"
 case 1277:
 /* rule 1277 can match eol */
-#line 7294 "tth.lex"
+#line 7296 "tth.lex"
 case 1278:
 /* rule 1278 can match eol */
-#line 7295 "tth.lex"
+#line 7297 "tth.lex"
 case 1279:
 /* rule 1279 can match eol */
-#line 7296 "tth.lex"
+#line 7298 "tth.lex"
 case 1280:
 /* rule 1280 can match eol */
-#line 7297 "tth.lex"
+#line 7299 "tth.lex"
 case 1281:
 /* rule 1281 can match eol */
 YY_RULE_SETUP
-#line 7297 "tth.lex"
+#line 7299 "tth.lex"
 if(horizmode)horizmode=1;
 	YY_BREAK
 case 1282:
-#line 7299 "tth.lex"
-case 1283:
-#line 7300 "tth.lex"
-case 1284:
 #line 7301 "tth.lex"
-case 1285:
+case 1283:
 #line 7302 "tth.lex"
-case 1286:
+case 1284:
 #line 7303 "tth.lex"
-case 1287:
+case 1285:
 #line 7304 "tth.lex"
+case 1286:
+#line 7305 "tth.lex"
+case 1287:
+#line 7306 "tth.lex"
 case 1288:
 YY_RULE_SETUP
-#line 7304 "tth.lex"
+#line 7306 "tth.lex"
 TTH_INC_MULTI;yy_push_state(matchbrace);
 	YY_BREAK
 case 1289:
-#line 7307 "tth.lex"
-case 1290:
-#line 7308 "tth.lex"
-case 1291:
 #line 7309 "tth.lex"
+case 1290:
+#line 7310 "tth.lex"
+case 1291:
+#line 7311 "tth.lex"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(pargroup):
 case YY_STATE_EOF(parclose):
@@ -26355,7 +26357,7 @@ case YY_STATE_EOF(uncommentgroup):
 case YY_STATE_EOF(urlgroup):
 case YY_STATE_EOF(indexgroup):
 case YY_STATE_EOF(halsearch):
-#line 7309 "tth.lex"
+#line 7311 "tth.lex"
 {
   if(!strcmp(yytext,"\\end")) {
     tth_stack_ptr=0; 
@@ -26367,6 +26369,7 @@ case YY_STATE_EOF(halsearch):
   }
   /*Function returns here*/
   if ( --tth_stack_ptr < 0){
+    tth_stack_ptr++;
     TTH_CLOSEGROUP;*closing=0;
     if(ftntno){
       TTH_SCAN_STRING("\\special{html:<hr /><h3>}\\tthfootnotes:\\special{html:</h3>\n}");
@@ -26424,7 +26427,7 @@ case YY_STATE_EOF(halsearch):
 	YY_BREAK
 case 1292:
 YY_RULE_SETUP
-#line 7374 "tth.lex"
+#line 7377 "tth.lex"
 { /* Don't suppose glue command in equations */
   TTH_CCPY(argchar,yytext);
   strcpy(argchar+strlen(argchar)-1,"\n=");
@@ -26434,13 +26437,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1293:
 YY_RULE_SETUP
-#line 7381 "tth.lex"
+#line 7384 "tth.lex"
 yy_push_state(unknown);
 	YY_BREAK
 /* Format looks like counter or dimension setting */
 case 1294:
 YY_RULE_SETUP
-#line 7384 "tth.lex"
+#line 7387 "tth.lex"
 {
   TTH_CCPY(argchar,yytext);
   argchar[strcspn(yytext," =")]=0;
@@ -26464,10 +26467,10 @@ YY_RULE_SETUP
  }    
 	YY_BREAK
 case 1295:
-#line 7407 "tth.lex"
+#line 7410 "tth.lex"
 case 1296:
 YY_RULE_SETUP
-#line 7407 "tth.lex"
+#line 7410 "tth.lex"
 { /* Not a tth native command */
   TTH_DO_MACRO
   else if( (ind=indexkey(yytext,countkeys,&ncounters)) != -1) { 
@@ -26487,40 +26490,43 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1297:
 YY_RULE_SETUP
-#line 7425 "tth.lex"
+#line 7428 "tth.lex"
 yy_push_state(matchbrace);
 	YY_BREAK
 case 1298:
 /* rule 1298 can match eol */
 YY_RULE_SETUP
-#line 7426 "tth.lex"
+#line 7429 "tth.lex"
 TTH_INC_MULTI;
 	YY_BREAK
 case 1299:
 /* rule 1299 can match eol */
 YY_RULE_SETUP
-#line 7427 "tth.lex"
+#line 7430 "tth.lex"
 yy_pop_state();yyless(0);
 	YY_BREAK
 case 1300:
 YY_RULE_SETUP
-#line 7429 "tth.lex"
+#line 7432 "tth.lex"
 strcat(psubstore,yytext);
 	YY_BREAK
 case 1301:
 YY_RULE_SETUP
-#line 7430 "tth.lex"
+#line 7433 "tth.lex"
 strcat(psubstore,yytext);
 	YY_BREAK
 case 1302:
 /* rule 1302 can match eol */
 YY_RULE_SETUP
-#line 7431 "tth.lex"
-TTH_INC_LINE;strcat(psubstore,yytext);
+#line 7434 "tth.lex"
+{
+  TTH_INC_LINE;strcat(psubstore,yytext);
+  if(tth_debug&8)fprintf(stderr,"NewLine in psub\n");
+}
 	YY_BREAK
 case 1303:
 YY_RULE_SETUP
-#line 7432 "tth.lex"
+#line 7438 "tth.lex"
 {
   strcat(psubstore,"#");
   if(tth_debug&8) fprintf(stderr,"Double # added to %s\n",psubstore);
@@ -26529,7 +26535,7 @@ YY_RULE_SETUP
 /* Changed * to + here 4 Nov 07 */
 case 1304:
 YY_RULE_SETUP
-#line 7437 "tth.lex"
+#line 7443 "tth.lex"
 { /* Add space after a command string, in case */
   if( (js2 = strcspn(yytext,"#")) ){
     strcpy(scratchstring,yytext);
@@ -26551,7 +26557,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1305:
 YY_RULE_SETUP
-#line 7455 "tth.lex"
+#line 7461 "tth.lex"
 {
   sscanf((yytext+strlen(yytext)-1),"%d",&i);
   if(tth_debug&8) fprintf(stderr,"dropping %d args\n",i);
@@ -26563,24 +26569,24 @@ YY_RULE_SETUP
   }
 	YY_BREAK
 case 1306:
-#line 7465 "tth.lex"
+#line 7471 "tth.lex"
 case 1307:
 YY_RULE_SETUP
-#line 7465 "tth.lex"
+#line 7471 "tth.lex"
 fprintf(stderr,"**** Internal Error: encountered %s\n",yytext);
 	YY_BREAK
 case 1308:
 /* rule 1308 can match eol */
 YY_RULE_SETUP
-#line 7467 "tth.lex"
+#line 7473 "tth.lex"
 {TTH_INC_MULTI;}
 	YY_BREAK
 case 1309:
-#line 7469 "tth.lex"
+#line 7475 "tth.lex"
 case 1310:
 /* rule 1310 can match eol */
 YY_RULE_SETUP
-#line 7469 "tth.lex"
+#line 7475 "tth.lex"
 {
   /* duplicated below  if(strcspn(yytext,"\n")==0) TTH_INC_LINE; */
   if(tth_debug&8){
@@ -26705,7 +26711,7 @@ YY_RULE_SETUP
 case 1311:
 /* rule 1311 can match eol */
 YY_RULE_SETUP
-#line 7589 "tth.lex"
+#line 7595 "tth.lex"
 {
   TTH_CHECK_LENGTH;
   TTH_INC_LINE;
@@ -26720,13 +26726,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 1312:
 YY_RULE_SETUP
-#line 7600 "tth.lex"
+#line 7606 "tth.lex"
 
 	YY_BREAK
 case 1313:
 /* rule 1313 can match eol */
 YY_RULE_SETUP
-#line 7601 "tth.lex"
+#line 7607 "tth.lex"
 {
   if(tth_debug&16)fprintf(stderr,"End of removespace:%s\n",yytext);
   yy_pop_state();yyless(0);
@@ -26735,21 +26741,21 @@ YY_RULE_SETUP
 case 1314:
 /* rule 1314 can match eol */
 YY_RULE_SETUP
-#line 7605 "tth.lex"
+#line 7611 "tth.lex"
 TTH_INC_MULTI;GET_DIMEN;
 	YY_BREAK
 case 1315:
 /* rule 1315 can match eol */
 YY_RULE_SETUP
-#line 7606 "tth.lex"
+#line 7612 "tth.lex"
 yyless(0);yy_pop_state();   
 	YY_BREAK
 case 1316:
 YY_RULE_SETUP
-#line 7608 "tth.lex"
+#line 7614 "tth.lex"
 ECHO;
 	YY_BREAK
-#line 26747 "lex.yy.c"
+#line 26753 "lex.yy.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -27786,7 +27792,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 7608 "tth.lex"
+#line 7614 "tth.lex"
 
 
  /********************************** CODE ******************************/

--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -1,8 +1,8 @@
 /* TtH TeX to HTML translator.
 TtH Version 
-"4.15"
+"4.16"
  (c) Ian Hutchinson
-Sat Sep 19 13:55:17 EDT 2020
+Mon Jul 25 08:59:50 EDT 2022
 */
 
 #line 3 "lex.yy.c"
@@ -14313,11 +14313,11 @@ This file needs to be turned into a C program using flex
 And then compiled into the tth executable using a C compiler.
 */
 #line 10 "tth.lex"
-#define TTH_VERSION "4.15"
+#define TTH_VERSION "4.16"
   /*#define TTH_GOLD "gold" no longer a distinction*/  /*sf*/
 #define TTH_HEAD "HEAD"  /*sf*/
 char tth_DOC[]="\n\
-                Version XXXX (c)1997-2020 Ian Hutchinson\n\
+                Version XXXX (c)1997-2022 Ian Hutchinson\n\
             TtH (TeX-to-HTML) translates TeX into HTML.\n\n\
 The program is a filter by default: it reads from stdin and writes to stdout.\n\
 But a non-switch argument specifies the file[.tex] to translate to file.html.\n\
@@ -21900,7 +21900,7 @@ YY_RULE_SETUP
   if(indexkey("\\amslatex",keys,&nkeys)!=-1){
     TTH_SCAN_STRING("\\verb|");
   }else{
-    TTH_OUTPUT(" - ");
+    if(strstr(closing,"/tt")){TTH_OUTPUT("|");}else{TTH_OUTPUT(" - ");}
   }
 } 
 	YY_BREAK

--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -95,10 +95,6 @@
   {\special{html:<div keyvals="#1">}\tthverbatim{lstlisting}}
   {\special{html:</div>}}
  
-\def\nolinkurl#1{\special{html:<span class="nolinkurl">}%
-  \verb|#1|%
-  \special{html:</span>}}
-
 \newenvironment{bigdescription}{%
     \begin{html}<div class="bigdescription">\end{html}
     \begin{description}\let\term\item


### PR DESCRIPTION
This contains two of our own patches (svn, nolinkurl).  The nolinkurl
part can hence go from tth-ivoa.tex.

Since we are about it, I've included yet another change (which is actually minor, but produces a large patch because of code generation), which brings this to tth 4.16.  This particular change fixes bug #85.