### PR TITLE
Fixes for standardsregext

### DIFF
--- a/schemadoc.xslt
+++ b/schemadoc.xslt
@@ -635,7 +635,9 @@ Copyright 2015, The GAVO project
 
   <xsl:template match="xs:documentation" mode="typedesc">
     <xsl:text>\noindent{\small</xsl:text>
-    <xsl:value-of select="."/>
+  	<xsl:call-template name="escape-for-TeX">
+ 			<xsl:with-param name="tx" select="."/>
+ 		</xsl:call-template>
     <xsl:text>\par}&#10;&#10;</xsl:text>
   </xsl:template>
 

--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -14616,7 +14616,7 @@ char *tth_builtins = "\\def\\bye{\\vfill\\eject\\end }\
 \\newenvironment{abstract}{\\begin{tthabstract}}{\\end{tthabstract}}\
 \\newcommand\\tthoutopt[1][]{#1}\n\
 \\newcommand\\tthnooutopt[1][]{}\n\
-\\def\\nolinkurl#!{\\verb!#1!}";
+\\def\\nolinkurl#1{\\verb!#1!}";
 
  /* static functions */
 static int indexkey();

--- a/update_generated.py
+++ b/update_generated.py
@@ -37,7 +37,12 @@ def escape_for_TeX(tx):
     """returns tx with TeX's standard active (and other magic) characters 
     escaped.
     """
-    return tx.replace("\\", "$\\backslash$"
+    # the $ is tricky because blindly replacing it with \$ will clash
+    # with my backslash replacement.  Let's hope nobody ever has a 
+    # sterling sign in their schemas...
+    return tx.replace("$", "£",
+        ).replace("\\", "$\\backslash$"
+        ).replace("£", "\\$"
         ).replace("&", "\\&"
         ).replace("#", "\\#"
         ).replace("%", "\\%"


### PR DESCRIPTION
These commits fix two unrelated bugs I noticed while processing StandardsRegExt, one concerning HTML formatting (rather new and hitting everyone), one concerning formatting of schema documentation (ancient and having so far not concerned anyone).