### PR TITLE
Improving width of admonition boxes in HTML

### DIFF
--- a/tth-ivoa.xslt
+++ b/tth-ivoa.xslt
@@ -57,7 +57,7 @@
         }
 
         div.admonition {
-          width: 30em;
+          width: 38%;
           position: relative;
           float: right;
           background-color: #dddddd;


### PR DESCRIPTION
The old fixed size didn't work terribly well across various browser widths. The new choice of 38% makes for a golden section between the box and the main text.  Ha!