### PR TITLE
Dropping doc.sty as a requirement for ivoa.cls.

### DIFF
--- a/ivoa.cls
+++ b/ivoa.cls
@@ -7,7 +7,6 @@
 \RequirePackage{graphicx}
 \RequirePackage{xcolor}
 \RequirePackage{ifthen}
-\RequirePackage{doc}
 \RequirePackage{listings}
 \RequirePackage{textcomp}
 \RequirePackage{paralist}


### PR DESCRIPTION
I don't think any of its facilities are (or should be) used by modern IVOA specs.  And it has caused #97.