### PR TITLE
added EPN-TAP reference from ADS to docrepo.bib

### DIFF
--- a/docrepo.bib
+++ b/docrepo.bib
@@ -1,3 +1,13 @@
+@MISC{2022ivoa.spec.0822E,
+       author = {{Erard}, St{\'e}phane and {Cecconi}, Baptiste and {Le Sidaner}, Pierre and {Demleitner}, Markus and {Taylor}, Mark},
+        title = "{EPN-TAP: Publishing Solar System Data to the Virtual Observatory Version 2.0}",
+ howpublished = {IVOA Recommendation 22 August 2022},
+         year = 2022,
+        month = aug,
+        pages = {822},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2022ivoa.spec.0822E},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 @MISC{2022ivoa.spec.0727F,
        author = {{Fernique}, Pierre and {Nebot}, Ada and {Durand}, Daniel and {Baumann}, Matthieu and {Boch}, Thomas and {Greco}, Giuseppe and {Donaldson}, Tom and {Pineau}, Francois-Xavier and {Taylor}, Mark and {O'Mullane}, Wil and {Reinecke}, Martin and {Derri{\`e}re}, S{\'e}bastien},
         title = "{MOC: Multi-Order Coverage map Version 2.0}",


### PR DESCRIPTION
I use this reference in the UCD1+ 1.5 specification. 
I noticed this specification is not yet in docrepo.bib  .

thanks for your update . ML