### PR TITLE
Updating the natbib style used by tth to something provided by Ian.

### DIFF
--- a/tthntbib.sty
+++ b/tthntbib.sty
@@ -1,11 +1,11 @@
 % Very simplified natbib macros for ivoatex and tth.
-% 
+%
 % This is for use with tth exclusively.
 %
 % We do not support multiple citations in one cite, any customisation,
 % etc -- just plain author (year) and (author, year); also the
 % three-argument forms are not supported.  Contributions are welcome.
-% 
+%
 % Since the tth braces don't work for us at all, we just turn them off
 % entirely and manage them ourselves.
 %
@@ -22,3 +22,5 @@
 \def\tthciteform##1##2##3##4{
 	(##3, ##2)}
 	\cite[#1]{#2}}
+
+\renewcommand\bibcite[4][]{\gdef}


### PR DESCRIPTION
This hopefully fixes a tth crash with overlong author lists.