### PR TITLE
Enlarging a TTH scratch buffer.

### DIFF
--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -14390,7 +14390,7 @@ Bit 16. 32768 Silence unknown command warnings.\n\
 #define GET_DIMEN {yy_push_state(lookforunit);yy_push_state(lookfornum);\
                    *argchar=0;}
 #define TTH_MAXDEPTH 30
-#define TTH_CHARLEN 500
+#define TTH_CHARLEN 5000
 #define TTH_DLEN 20000
 #define TTH_34DLEN 72000
 #define TTH_FONTLEN 200


### PR DESCRIPTION
Without this, tth stack-smashes even with just a few lines of author list and my natbib hack.  With this larger buffer, that'll only happen with a few pages of authors.

Since tth doesn't play games with privileges and in an ivoatex context, people can run whatever code anyway, I'd say that's acceptable, at least until upstream plugs the overwrite as such.