### PR TITLE
Fix some whitespace issues in macros

### DIFF
--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -108,8 +108,7 @@
 \renewcommand{\customcss}[1]{%
   \begin{html}<span class="customcss" ref="#1"/>\end{html}}
 
-\newcommand{\specialterm}[2]{%
-  \begin{html}<span class="#1">\end{html}#2\begin{html}</span>\end{html}}
+\newcommand{\specialterm}[2]{\begin{html}<span class="#1">\end{html}#2\begin{html}</span>\end{html}}
 \newcommand{\xmlel}[1]{\specialterm{xmlel}{#1}}
 \newcommand{\vorent}[1]{\specialterm{vorent}{#1}}
 \newcommand{\ucd}[1]{{\sl #1}}
@@ -119,16 +118,14 @@
 
 \def\dquote{"}
 
-\newcommand{\todo}[2][None]{%
-  \begin{html}<span class="redaction">#2</span>\end{html}}
+\newcommand{\todo}[2][None]{\begin{html}<span class="redaction">#2</span>\end{html}}
 
 \newenvironment{SCfigure}{\begin{figure}}{\end{figure}}
 
-\newcommand{\ivoatex}{%
-  \special{html:<span class="ivoatex">IVOAT<sub>E</sub>X</span>}}
+\newcommand{\ivoatex}{\special{html:<span class="ivoatex">IVOAT<sub>E</sub>X</span>}}
 
 \newcommand{\auxiliaryurl}[1]{% don't use href, we need expansion
-  \special{html:<a href="}https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1\special{html:">}%
+\special{html:<a href="}https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1\special{html:">}%
 https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1%
 \special{html:</a>}}
 


### PR DESCRIPTION
Macros whose definitions include newlines for cosmetic reasons can in some cases result in unwanted significant whitespace in HTML output. This addresses issue #115 as advised by @msdemlei; for \specialterm, \todo and \ivoatex by allowing long lines in the LaTeX source to avoid the line break, and for \auxiliaryurl by stripping cosmetic whitespace at the start of a line after a "%" character at the end of the previous line (since otherwise in that case the source line would get very long).

I've tested that this fix has the desired effect for \specialterm (via \xmlel in DALI), but not for the others.