### PR TITLE
Fix url formatting

### DIFF
--- a/ivoa.bst
+++ b/ivoa.bst
@@ -54,7 +54,7 @@ ENTRY
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block }
 
-STRINGS { s t f doi.url doi.prefix arxiv.prefix }
+STRINGS { s t f doi.http.url doi.https.url doi.prefix arxiv.prefix }
 
 FUNCTION {init.state.consts}
 { #0 'before.all :=
@@ -62,7 +62,8 @@ FUNCTION {init.state.consts}
   #2 'after.sentence :=
   #3 'after.block :=
 
-  "https://doi.org/" 'doi.url := % prefix to make URL from DOI (used to be dx.doi.org)
+  "https://doi.org/" 'doi.https.url := % prefix to make URL from DOI (used to be dx.doi.org)
+  "http://doi.org/" 'doi.http.url := % the non-SSL version of that
   "doi:" 'doi.prefix :=          % formatting prefix
   % we're presuming here that all eprints are at arXiv
   "arXiv:" 'arxiv.prefix :=      % formatting prefix
@@ -172,19 +173,34 @@ FUNCTION {quote}
 }
 
 % Minimal DOI parsing.
-% Given a DOI on the stack, check whether it starts with 'doi.url' or not.
+% Given a string, strips either "http://doi.org/" (15 chars) or
+% "https://doi.org/" (16) from the front of it.
+% If the string doesn't start with either, then leave it alone.
+FUNCTION {strip.doi.prefix}
+{
+  duplicate$
+  #1 #15 substring$
+  "http://doi.org/" =
+    { #16 #999 substring$ }
+    { duplicate$
+      #1 #16 substring$
+      "https://doi.org/" =
+        { #17 #999 substring$ }
+        'skip$
+      if$ }
+  if$
+}
+
+% Given a DOI on the stack, check whether it starts with 'doi.http(s).url' or not.
 % In either case, leave on the stack first a DOI with,
 % and then a DOI without, the URL prefix
-% (ie, stack-top: doi doi-link)
+% (ie, stack-top: doi doi-url)
 FUNCTION {parse.doi}
 {
-  #1 doi.url text.length$ substring$
-  doi.url =
-    { doi
-      doi doi.url text.length$ #1 + #999 substring$ }
-    { doi.url doi *
-      doi }
-  if$
+  strip.doi.prefix
+  duplicate$
+  doi.https.url swap$ *         %put the prefix back on one
+  swap$
 }
 
 % Given (stack-top: link-text URL), make an href link
@@ -227,34 +243,25 @@ FUNCTION {protect.url}
 % at http://tex.stackexchange.com/questions/5660)
 FUNCTION {write.url.and.doi}
 { new.block
-  URL empty$
-    { doi empty$
-        { adsurl empty$
-            { skip$ }
-            { adsurl make.url output.nonnull }
-          if$
-        }
-        { doi.prefix doi parse.doi
-          % Only a few DOIs have characters that need protecting by
-          % the \url macro (from the 'url' package), but we protect
-          % all of them here, just in case.
-          protect.url
-          make.href * output.nonnull
-        }
-      if$
-    }
-    { doi empty$
-        { URL make.url output.nonnull }  % no DOI: simple case
-        { doi parse.doi swap$   % stack top: doi-url doi
-          duplicate$
-          url =
-            { pop$ pop$ }              % DOI and URL refer to same, don't print the DOI
-            { swap$ make.href doi.prefix swap$ * output.nonnull}
-          if$
-          URL make.url output.nonnull
-        }
-      if$
-    }
+  "x" 't :=                     %possibly replaced by DOI URL
+  doi empty$
+    'skip$
+    { doi parse.doi swap$       % stack top: doi-url doi
+      duplicate$ 't :=          %save DOI URL
+      swap$ protect.url
+      make.href
+      doi.prefix swap$ * output.nonnull }
+  if$
+  url empty$
+    { adsurl empty$
+        'skip$
+        { adsurl make.url output.nonnull }
+      if$ }
+    { t strip.doi.prefix        % t is still "x" if there's no DOI
+      url strip.doi.prefix =
+        'skip$   % DOI and URL refer to same, don't print the URL
+        { url make.url output.nonnull }
+      if$ }
   if$
 }
 

--- a/ivoa.bst
+++ b/ivoa.bst
@@ -15,6 +15,12 @@
 %   Peter Williams, Key Centre for Design Quality, Sydney University
 %   e-mail: peterw@archsci.arch.su.oz.au
 
+% Some further DOI-related adjustments from Norman Gray <norman.gray@glasgow.ac.uk>.
+% Note: these adjustments assume (a) that the `url` package is loaded,
+% so that the `\url` macro is available, and (b) that the `hyperref`
+% package is loaded, so that the `\nolinkurl` macro is available to
+% provide a no-link version of the escaping that `url` provides.
+
 ENTRY
   { address
     author
@@ -191,9 +197,23 @@ FUNCTION {make.href}
 % Wrap the string at the top of the stack in \url{...}
 % (from the 'url' package).
 % See the note about \doi{...} below.
-FUNCTION {protect.with.url}
+FUNCTION {make.url}
 {
   "\url{" swap$ * "}" *
+}
+
+% Wrap the string at the top of the stack in... something which
+% protects it, without making it a linked  URL.  This would be
+% \url{...}, but the hyperref package turns this into a link, which
+% messes up DOIs.  That package adds \nolinkurl for this purpose.
+%
+% This typically formats URLs in a tt-font. This isn't pretty, but we
+% shouldn't second-guess the formatting here.  A possibly better
+% solution would be to \DeclareUrlCommand\doi{\urlstyle{rm}}, and
+% protect these with \doi instead.
+FUNCTION {protect.url}
+{
+  "\nolinkurl{" swap$ * "}" *
 }
 
 % Write out URL and DOI entries.
@@ -211,31 +231,27 @@ FUNCTION {write.url.and.doi}
     { doi empty$
         { adsurl empty$
             { skip$ }
-            { "\url{" adsurl * "}" * output.nonnull }
+            { adsurl make.url output.nonnull }
           if$
         }
         { doi.prefix doi parse.doi
           % Only a few DOIs have characters that need protecting by
           % the \url macro (from the 'url' package), but we protect
-          % all of them here, just in case.  This typically formats
-          % URLs in a tt-font. This isn't pretty, but we shouldn't
-          % second-guess the formatting here.  A better solution would
-          % be to \DeclareUrlCommand\doi{\urlstyle{rm}}, and protect
-          % these with \doi instead.
-          protect.with.url
+          % all of them here, just in case.
+          protect.url
           make.href * output.nonnull
         }
       if$
     }
     { doi empty$
-        { "\url{" URL * "}" * output.nonnull }  % no DOI: simple case
+        { URL make.url output.nonnull }  % no DOI: simple case
         { doi parse.doi swap$   % stack top: doi-url doi
           duplicate$
           url =
             { pop$ pop$ }              % DOI and URL refer to same, don't print the DOI
             { swap$ make.href doi.prefix swap$ * output.nonnull}
           if$
-          "\url{" URL * "}" * output.nonnull
+          URL make.url output.nonnull
         }
       if$
     }

--- a/test/test-ivoa-bst-urls.aux
+++ b/test/test-ivoa-bst-urls.aux
@@ -3,23 +3,15 @@
 % When run through BibTeX, this aux file should produce references for the
 % following citations, in this order
 
-\bibdata{ivoabib}
+\bibdata{test-ivoa-bst-urls}
 \bibstyle{ivoa}
-
-% DOI with no prefix
-\citation{2014A+C.....7...27D}
-
-% std:FITS has DOI but no URL
-\citation{std:FITS}
-
-% URL but no DOI
-\citation{std:CSV}
-
-% DOI with https prefix and URL
-\citation{std:DataCite31}
-
-% DOI with matching URL
-\citation{Wilkinson2016}
-
-% The result of `grep -Ei '(harvarditem|doi|url)' test-ivoa-bst-urls.bbl`
-% should be as in test-ivoa-bst-urls.good
+\citation{t1}
+\citation{t2}
+\citation{t3}
+\citation{t4}
+\citation{t5}
+\citation{t6}
+\citation{t7}
+\citation{t8}
+\citation{t9}
+\citation{t10}

--- a/test/test-ivoa-bst-urls.bib
+++ b/test/test-ivoa-bst-urls.bib
@@ -1,0 +1,90 @@
+
+Nothing
+@Misc{t1,
+  author =       {A Alpha},
+  title =        {Test 1},
+  year =         {2001}
+}
+
+bare DOI, no URL
+@Misc{t2,
+  author =       {B Bravo},
+  title =        {Test 2},
+  year =         {2002},
+  doi =          {10.0002/0002}
+}
+
+bare DOI with URL
+(incidentally with a scheme which isn't http or
+https, to check we don't fail in this case)
+@Misc{t3,
+  author =       {C Charlie},
+  title =        {Test 3},
+  year =         {2003},
+  doi =          {10.0003/0003},
+  url =          {ldap://example.org/0003}
+}
+
+bare DOI with adsURL
+@Misc{t4,
+  author =       {D Delta},
+  title =        {Test 4},
+  year =         {2004},
+  doi =          {10.0004/0004},
+  adsurl =       {http://example.org/0004}
+}
+
+http DOI; no URL
+@Misc{t5,
+  author =       {E Echo},
+  title =        {Test 5},
+  year =         {2005},
+  doi =          {http://doi.org/10.0005/0005}
+}
+
+https DOI, no URL
+@Misc{t6,
+  author =       {F Foxtrot},
+  title =        {Test 6},
+  year =         {2006},
+  doi =          {https://doi.org/10.0006/0006}
+}
+
+bare DOI with matching http URL
+@Misc{t7,
+  author =       {G Golf},
+  title =        {Test 7},
+  year =         {2007},
+  doi =          {10.0007/0007},
+  url =          {http://doi.org/10.0007/0007}
+}
+
+bare DOI with matching https URL
+@Misc{t8,
+  author =       {H Hotel},
+  title =        {Test 8},
+  year =         {2008},
+  doi =          {10.0008/0008},
+  url =          {https://doi.org/10.0008/0008}
+}
+
+http DOI with matching https URL
+@Misc{t9,
+  author =       {I India},
+  title =        {Test 9},
+  year =         {2009},
+  doi =          {http://doi.org/10.0009/0009},
+  url =          {https://doi.org/10.0009/0009}
+}
+
+https DOI with matching http URL
+@Misc{t10,
+  author =       {J Juliet},
+  title =        {Test 10},
+  year =         {2010},
+  doi =          {https://doi.org/10.0010/0010},
+  url =          {http://doi.org/10.0010/0010}
+}
+
+We won't bother looking at an adsurl starting doi.org,
+since I don't think that ever happens

--- a/test/test-ivoa-bst-urls.good
+++ b/test/test-ivoa-bst-urls.good
@@ -1,9 +1,9 @@
 \harvarditem[{Demleitner} \harvardand\ {Neves} et~al.]{{Demleitner}, {Neves},
 \newblock doi:\href {https://doi.org/10.1016/j.ascom.2014.08.003}
-  {\url{10.1016/j.ascom.2014.08.003}}.
+  {\nolinkurl{10.1016/j.ascom.2014.08.003}}.
 \harvarditem[{Hanisch} \harvardand\ {Farris} et~al.]{{Hanisch}, {Farris},
 \newblock doi:\href {https://doi.org/10.1051/0004-6361:20010923}
-  {\url{10.1051/0004-6361:20010923}}.
+  {\nolinkurl{10.1051/0004-6361:20010923}}.
 \harvarditem{Shafranovich}{2005}{std:CSV}
 \newblock \url{https://tools.ietf.org/html/rfc4180}.
 \harvarditem{Starr et~al.}{2015}{std:DataCite31}

--- a/test/test-ivoa-bst-urls.good
+++ b/test/test-ivoa-bst-urls.good
@@ -1,14 +1,44 @@
-\harvarditem[{Demleitner} \harvardand\ {Neves} et~al.]{{Demleitner}, {Neves},
-\newblock doi:\href {https://doi.org/10.1016/j.ascom.2014.08.003}
-  {\nolinkurl{10.1016/j.ascom.2014.08.003}}.
-\harvarditem[{Hanisch} \harvardand\ {Farris} et~al.]{{Hanisch}, {Farris},
-\newblock doi:\href {https://doi.org/10.1051/0004-6361:20010923}
-  {\nolinkurl{10.1051/0004-6361:20010923}}.
-\harvarditem{Shafranovich}{2005}{std:CSV}
-\newblock \url{https://tools.ietf.org/html/rfc4180}.
-\harvarditem{Starr et~al.}{2015}{std:DataCite31}
-\newblock doi:\href {https://doi.org/http://doi.org/10.5438/0010}
-  {http://doi.org/10.5438/0010},
-  \url{https://schema.datacite.org/meta/kernel-3.1/doc/DataCite-MetadataKernel_v3.1.pdf}.
-\harvarditem[Wilkinson \harvardand\ Dumontier et~al.]{Wilkinson, Dumontier,
-\newblock \url{https://doi.org/10.1038/sdata.2016.18}.
+\begin{thebibliography}{xx}
+
+\harvarditem{Alpha}{2001}{t1}
+Alpha, A.  \harvardyearleft 2001\harvardyearright , `Test 1'.
+
+\harvarditem{Bravo}{2002}{t2}
+Bravo, B.  \harvardyearleft 2002\harvardyearright , `Test 2'.
+\newblock doi:\href {https://doi.org/10.0002/0002} {\nolinkurl{10.0002/0002}}.
+
+\harvarditem{Charlie}{2003}{t3}
+Charlie, C.  \harvardyearleft 2003\harvardyearright , `Test 3'.
+\newblock doi:\href {https://doi.org/10.0003/0003} {\nolinkurl{10.0003/0003}},
+  \url{ldap://example.org/0003}.
+
+\harvarditem{Delta}{2004}{t4}
+Delta, D.  \harvardyearleft 2004\harvardyearright , `Test 4'.
+\newblock doi:\href {https://doi.org/10.0004/0004} {\nolinkurl{10.0004/0004}},
+  \url{http://example.org/0004}.
+
+\harvarditem{Echo}{2005}{t5}
+Echo, E.  \harvardyearleft 2005\harvardyearright , `Test 5'.
+\newblock doi:\href {https://doi.org/10.0005/0005} {\nolinkurl{10.0005/0005}}.
+
+\harvarditem{Foxtrot}{2006}{t6}
+Foxtrot, F.  \harvardyearleft 2006\harvardyearright , `Test 6'.
+\newblock doi:\href {https://doi.org/10.0006/0006} {\nolinkurl{10.0006/0006}}.
+
+\harvarditem{Golf}{2007}{t7}
+Golf, G.  \harvardyearleft 2007\harvardyearright , `Test 7'.
+\newblock doi:\href {https://doi.org/10.0007/0007} {\nolinkurl{10.0007/0007}}.
+
+\harvarditem{Hotel}{2008}{t8}
+Hotel, H.  \harvardyearleft 2008\harvardyearright , `Test 8'.
+\newblock doi:\href {https://doi.org/10.0008/0008} {\nolinkurl{10.0008/0008}}.
+
+\harvarditem{India}{2009}{t9}
+India, I.  \harvardyearleft 2009\harvardyearright , `Test 9'.
+\newblock doi:\href {https://doi.org/10.0009/0009} {\nolinkurl{10.0009/0009}}.
+
+\harvarditem{Juliet}{2010}{t10}
+Juliet, J.  \harvardyearleft 2010\harvardyearright , `Test 10'.
+\newblock doi:\href {https://doi.org/10.0010/0010} {\nolinkurl{10.0010/0010}}.
+
+\end{thebibliography}

--- a/test/test-ivoa-bst-urls.sh
+++ b/test/test-ivoa-bst-urls.sh
@@ -2,14 +2,15 @@
 
 name=test-ivoa-bst-urls
 
-BIBINPUTS=.. BSTINPUTS=.. bibtex $name >$name.stdout
-grep -Ei '(harvarditem|doi|url)' $name.bbl >$name.out
+BSTINPUTS=.. bibtex $name >$name.stdout
+#grep -Ei '(harvarditem|doi|url)' $name.bbl >$name.out
+#mv $name.bbl $name.out
 
 status=0
 
-if diff $name.good $name.out >$name.diff; then
+if diff $name.good $name.bbl >$name.diff; then
     echo "$0 good"
-    for e in bbl blg out diff stdout; do rm $name.$e; done
+    for e in bbl blg diff stdout; do rm $name.$e; done
 else
     echo "$0 failed: diffs in $name.diff"
     status=1


### PR DESCRIPTION
The two commits here fix errors in the previous attempt to update `ivoa.bst` to accommodate DOIs, which became manifest when this was tried with the VOUnits.tex file.  See the commit notes for details.