### PR TITLE
Bloating tth buffers a bit to prevent crashes on arm64.

### DIFF
--- a/tth_C/UPDATING
+++ b/tth_C/UPDATING
@@ -36,4 +36,16 @@ Note 2023-07: Upstream still has TTH_CHARLEN 500, which is trouble on
 certain compilers with large bibliography items
 (https://github.com/ivoa-std/ivoatex/pull/104).  *If* you put in new code
 from upstream, until the relevant buffer overflows are fixed, manually bump
-this to 5000.
+this to 5000.  Similarly, (some of) the following buffers overflow on
+harmless document builds) on clang:
+
+	STATIC char environment[20]={0};   /* Name of environment */
+	STATIC char labelchar[20]={0}; /* Running label in current section. */
+	STATIC char envirchar[20]={0}; /* Running label in numbered environment. */
+	STATIC char refchar[20]={0};   /* Type of internal reference. */
+	STATIC char colorchar[20]={0};
+	STATIC char filechar[20]={0};
+	STATIC char filenext[20]={0}; /*sf*/
+	STATIC char auxflch[20]={0};
+
+For now, let's push them to 200.

--- a/tth_C/tth.c
+++ b/tth_C/tth.c
@@ -15269,14 +15269,14 @@ STATIC int countstart=0;
 #define partno counters[8+countstart]
 #define secnumdepth counters[9+countstart]
 STATIC int appendix=0;
-STATIC char environment[20]={0};   /* Name of environment */
-STATIC char labelchar[20]={0}; /* Running label in current section. */
-STATIC char envirchar[20]={0}; /* Running label in numbered environment. */
-STATIC char refchar[20]={0};   /* Type of internal reference. */
-STATIC char colorchar[20]={0};
-STATIC char filechar[20]={0};
-STATIC char filenext[20]={0}; /*sf*/
-STATIC char auxflch[20]={0};
+STATIC char environment[200]={0};   /* Name of environment */
+STATIC char labelchar[200]={0}; /* Running label in current section. */
+STATIC char envirchar[200]={0}; /* Running label in numbered environment. */
+STATIC char refchar[200]={0};   /* Type of internal reference. */
+STATIC char colorchar[200]={0};
+STATIC char filechar[200]={0};
+STATIC char filenext[200]={0}; /*sf*/
+STATIC char auxflch[200]={0};
 STATIC char schar[3]={0}; /*sf*/
 #define TNO 400
 STATIC char *tchar[TNO]={0}; /*sf*/


### PR DESCRIPTION
Of course, it's not hard to craft TeX documents that will crash this, too. But tth is not a security boundary here, so I am about as unconcerned about its exploitability as upstream.