### PR TITLE
Support for tikz images in pdf and html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ PYTHON?=python3
 #     zip
 #     librsvg2-bin or inkscape (for architecture diagrams)
 #     pdftk if you want to build draft pdfs with a watermark
+#     pdf2svg when you have TikZ-based vector graphics
 #     optionally, latexmk.
 #  If you don't have librsvg2 but you do have inkscape, you
 #  can set the SVGENGINE environment variable to inkscape.
@@ -171,6 +172,12 @@ else
 	rsvg-convert --output=$@ --format=pdf $< \
 		|| cp ivoatex/svg-fallback.pdf $@
 endif
+
+%.tikz.pdf: %.tikz.tex
+	pdflatex -jobname=$*.tikz '\documentclass[crop,tikz,multi=false]{standalone}\begin{document}\input '$<'\end{document}'
+
+%.tikz.svg: %.tikz.pdf
+	pdf2svg $< $@
 
 # generate may modify DOCNAME.tex controlled by arbitrary external binaries.
 # It is impossible to model these dependencies (here), and anyway

--- a/ivoa.cls
+++ b/ivoa.cls
@@ -370,6 +370,8 @@
 
 \chardef\dquote'042
 
+\newcommand{\tikzfigure}[1]{\input{#1.tikz.tex}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Changing LaTeX/package defaults
 
 \renewcommand*\descriptionlabel[1]

--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -129,6 +129,10 @@
 https://www.ivoa.net/documents/\ivoaDocname/\ivoaDocdatecode/#1%
 \special{html:</a>}}
 
+\newcommand{\tikzfigure}[1]{\special{html:<img
+  src="}#1.tikz.svg\special{html:" alt="Sorry. No alt from LaTeX"
+  class="svgimage"/>}}
+
 \newenvironment{inlinetable}{}{}
 
 % TODO: support some common styles


### PR DESCRIPTION
Admittedly it would be a lot cooler if tth could produce inline svgs from tikz.  But that's totally utopian.

With the facilities here, at least things work, and the graphics end up scalably in both HTML and PDF.

This goes together with ivoatex PR 40.

And yes, I realise I'm not covering this with a regression test.  I promise I'll add one once the first IVOA document not written by me has a TikZ image (I'm not holding my breath, although TikZ is of course brilliant).