### PR TITLE
gitmeta inclusion is now in the templates

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -19,7 +19,7 @@ AUTHOR_EMAIL=???
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex)
-SOURCES = $(DOCNAME).tex
+SOURCES = $(DOCNAME).tex gitmeta.tex
 
 # List of image files to be included in submitted package (anything that
 # can be rendered directly by common web browsers)

--- a/document.template
+++ b/document.template
@@ -1,5 +1,6 @@
 \documentclass[11pt,a4paper]{ivoa}
 \input tthdefs
+\input gitmeta
 
 \title{???? Full title ????}
 

--- a/regressiontest/README.rst
+++ b/regressiontest/README.rst
@@ -7,6 +7,13 @@ changes, this is a regression test that goes through the motions of
 starting a document and building it, exercising as many of the features
 mentioned in ivoatexDoc as I can.
 
+To see if you have broken anything, just commit your changes into a
+branch and run::
+
+  python run-regression.py --branch <your-branch-name>
+
+By default, run-regression will exercise the master branch.
+
 See the docstring in run-regression.py on how to add to the tests.
 
 Maintained by Markus Demleitner <msdemlei@ari.uni-heidelberg.de>

--- a/regressiontest/run-regression.py
+++ b/regressiontest/run-regression.py
@@ -341,10 +341,6 @@ def test_auxiliaryurl_and_test():
 
 def test_git_integration():
     execute("git init")
-    edit_file("Makefile", [
-        ("SOURCES = ", "SOURCES = gitmeta.tex ")])
-    edit_file("Regress.tex", [
-        (r"\input tthdefs", "\\input tthdefs\n\\input gitmeta")])
     execute("make")
     execute("pdftotext Regress.pdf")
 


### PR DESCRIPTION
ivoatex could record the repo URI (in SVN) or the commit id (in git) on the document front page forever, but too few documents actually are actually using that right now.  As a remedy, this commit makes using this information the default in the templates.

A downside is that documents not under version control cannot be built out of the box (people first need to remove the \input gitmeta from their document and the gitmeta.tex dependency in the Makefile).  But people who cannot figure that out probably don't actually want to do that, and so a build failure may actually be an advantage in that it uncovers an actual mistake earlier.