### PR TITLE
adding TCG to wg mappings

### DIFF
--- a/submission.py
+++ b/submission.py
@@ -181,6 +181,7 @@ class DocumentMeta(object):
           "Standards and Processes": "std",
           "Semantics": "semantics",
           "Theory": "the",
+          "Technical Coordination Group": "tcg",
           "VO Event": "voe",
           "Time Domain": "voe",
           "Education": "edu",


### PR DESCRIPTION
I tried to add the IVOA Architecture PEN and got stuck because the submission system doesn't recognise TCG as a possible submitter. I fixed it server side, this one-line update should fix the ivoatex make upload accordingly.