### PR TITLE
Update CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,14 +319,18 @@ $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 github-preview: $(GITHUB_BUILD) $(GITHUB_PREVIEW)
 
 check-clear-ci:
-	@echo "* You are about to remove the current following GitHub workflows:\n    - $(GITHUB_BUILD)\n    - $(GITHUB_PREVIEW)"
-	@read -p "  => Are you sure you want to remove them? [y/N] " ans && ans=$${ans:-N} ; \
-    ans=$$(echo $${ans} | tr '[:upper:]' '[:lower:]') ; \
-    [ $${ans} = y ] || [ $${ans} = yes ]
+	@if [ -f "$(GITHUB_BUILD)" -o -f "$(GITHUB_PREVIEW)" ]; then \
+	  echo "* You are about to remove the current following GitHub workflows:\n    - $(GITHUB_BUILD)\n    - $(GITHUB_PREVIEW)" ; \
+	  read -p "  => Are you sure you want to remove them? [y/N] " ans && ans=$${ans:-N} ; \
+      ans=$$(echo $${ans} | tr '[:upper:]' '[:lower:]') ; \
+      [ $${ans} = y ] || [ $${ans} = yes ] ; \
+	fi
 
 clear-ci: check-clear-ci
-	@rm $(GITHUB_BUILD) $(GITHUB_PREVIEW)
-	@echo "  => GitHub workflows removed."
+	@if [ -f "$(GITHUB_BUILD)" -o -f "$(GITHUB_PREVIEW)" ]; then \
+	  rm -f $(GITHUB_BUILD) $(GITHUB_PREVIEW) && \
+	  echo "  => GitHub workflows removed." ; \
+	fi
 
 update-ci: clear-ci github-preview
 

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ docrepo.bib:
 
 ############# GitHub workflows configuration
 
-.PHONY: github-preview
+.PHONY: github-preview check-clear-ci clear-ci update-ci
 
 GITHUB_WORKFLOWS        = .github/workflows
 GITHUB_BUILD            = $(GITHUB_WORKFLOWS)/build.yml
@@ -298,14 +298,15 @@ $(GITHUB_WORKFLOWS):
 $(GITHUB_BUILD): $(GITHUB_WORKFLOWS) $(GITHUB_BUILD_TEMPLATE)
 	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_BUILD_TEMPLATE) > $@
 	@git add "$@"
-	@echo -e "* GitHub Workflow for PDF preview in PullRequest configured:\n      $@"
-	@echo '  => Run "git commit && git push" to enable GitHub PDF preview.'
+	@echo "* GitHub Workflow Build (to check compilation of the IVOA document)\
+	         \n  in PullRequest configured:\n                 $@"
+	@echo '  => Run "git commit && git push" to enable this Build workflow.'
 
 $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_PREVIEW_TEMPLATE) > $@
 	@git add "$@"
-	@echo -e "* GitHub Workflow for PDF preview at pushed commit configured:\n\
-	        $@\n\
+	@echo "* GitHub Workflow for PDF preview at pushed commit configured:\
+	         \n                 $@\n\
 	  -----------------------------------------------------------------------\n\
 	    Clickable badge toward the generated PDF preview:\n\n\
 	        [![PDF-Preview](https://img.shields.io/badge/Preview-PDF-blue)]\
@@ -316,6 +317,18 @@ $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
 	@echo '  => Run "git commit && git push" to enable GitHub PDF preview.'
 
 github-preview: $(GITHUB_BUILD) $(GITHUB_PREVIEW)
+
+check-clear-ci:
+	@echo "* You are about to remove the current following GitHub workflows:\n    - $(GITHUB_BUILD)\n    - $(GITHUB_PREVIEW)"
+	@read -p "  => Are you sure you want to remove them? [y/N] " ans && ans=$${ans:-N} ; \
+    ans=$$(echo $${ans} | tr '[:upper:]' '[:lower:]') ; \
+    [ $${ans} = y ] || [ $${ans} = yes ]
+
+clear-ci: check-clear-ci
+	@rm $(GITHUB_BUILD) $(GITHUB_PREVIEW)
+	@echo "  => GitHub workflows removed."
+
+update-ci: clear-ci github-preview
 
 help:
 	@echo Documentation on IVOATeX is available at

--- a/github_workflow_build.yml.template
+++ b/github_workflow_build.yml.template
@@ -21,7 +21,7 @@ jobs:
     steps:
 
     - name: Checkout the repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/github_workflow_build.yml.template
+++ b/github_workflow_build.yml.template
@@ -39,7 +39,7 @@ jobs:
         test -f ${{ env.doc_name }}.bbl
 
     - name: Keep the PDF artefact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: PDF Preview
         path: ${{ env.doc_name }}.pdf

--- a/github_workflow_build.yml.template
+++ b/github_workflow_build.yml.template
@@ -28,7 +28,9 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt update
-        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
+        sudo apt install texlive-latex-base texlive-latex-recommended \
+                         texlive-latex-extra texlive-fonts-recommended
+                         pdftk xsltproc latexmk cm-super
 
     - name: Build the document
       run: make

--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -30,12 +30,12 @@ jobs:
 
     - name: Setup dependencies
       run: |
-        sudo apt update
-        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
-        sudo snap install pdftk
+        sudo apt install texlive-latex-base texlive-latex-recommended \
+                         texlive-latex-extra texlive-fonts-recommended
+                         pdftk xsltproc latexmk cm-super
 
     - name: Build the document
-      run: make ${{ env.doc_name }}-draft.pdf
+      run: make biblio ${{ env.doc_name }}-draft.pdf
 
     - name: Check the output
       run: |

--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Checkout the repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -7,7 +7,9 @@
 name: Update PDF Preview
 
 env:
-  doc_name:
+  doc_name   :
+  branch_name: ${{ github.head_ref || github.ref_name }}
+  tag_preview: auto-pdf-preview
 
 on:
   push:
@@ -40,27 +42,25 @@ jobs:
         test -f ${{ env.doc_name }}-draft.pdf
         test -f ${{ env.doc_name }}.bbl
 
-    - name: Move the auto-pdf-preview tag
-      uses: weareyipyip/walking-tag-action@v2
-      with:
-        tag-name: auto-pdf-preview
-        tag-message: |
-          Last commit taken into account for the automatically updated PDF preview of this IVOA document.
+    - name: Remove the former PDF preview
+      run: |
+        gh release delete ${{ env.tag_preview }} --cleanup-tag --yes
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Update the PDF preview
-      uses: Xotl/cool-github-releases@v1
-      with:
-        mode: update
-        isPrerelease: true
-        tag_name: auto-pdf-preview
-        release_name: "Auto PDF Preview"
-        body_mrkdwn: |
-          This release aims to provide a PDF preview of the last commit applied on this repository.
+    - name: Upload the new PDF preview
+      run: |
+        RELEASE_NOTES="This release aims to provide a PDF preview of the last commit applied on this repository.
           It will be updated automatically after each merge of a PullRequest.
-          **DO NOT PUBLISH THIS PRE-RELEASE!**"
-          _Corresponding commit: ${{ github.sha }}_
-        assets: ${{ env.doc_name }}-draft.pdf
-        replace_assets: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+          **DO NOT PUBLISH THIS PRE-RELEASE!**
+          _Corresponding commit: ${{ github.sha }}_"
+
+        gh release create ${{ env.tag_preview }} \
+                          ${{ env.doc_name }}-draft.pdf \
+                          --prerelease \
+                          --target "${{ env.branch_name }}" \
+                          --title 'Auto PDF Preview' \
+                          --notes "$RELEASE_NOTES"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This PullRequest should solve issues related to deprecated GitHub actions when checking the IVOA document and generating its PDF preview (see #140).

In more details:

- Update the official GitHub actions: `actions/checkout` (to checkout the Git repository in the CI container) and `actions/upload-artifact` (to keep the artifact - the PDF preview - on GitHub for some time)
- Replace the unofficial GitHub actions `weareyipyip/walking-tag-action` (to move tag `auto-pdf-preview` to the last commit) and `Xotl/cool-github-releases` (to create a Pre-Release with a same name to give access to the PDF preview with a constant URL) with simple standard GitHub CLI commands
  - thus, we should no longer have version issues with these GitHub actions
  - this also solves a silent issue: each time the CI ran, the former Pre-Release was transformed into a Draft while another Pre-Release with the same name is created. Then, all former Pre-Releases stay available on the GitHub repository as Drafts instead of being removed ; this generated quickly a lot of pollution.
- Add 2 targets in the Makefile:
  - `clear-ci`: remove the two GitHub workflows (build and PDF preview)
  - `update-ci`: remove existing GitHub workflows (build and PDF preview only) and configure them again with the template workflows available in ivoatex ; this command is exactly the same as `make clear-ci github-preview`.
- Update the explanations when configuring the Build workflow. It is not related to the PDF preview, it just checks that the IVOA document can compile successfully.
- Update the APT packages to install in the CI container (pdftk seems now to be available in APT)

Fixes #140 

------

Instructions for maintainers of the repositories already using these workflows to update their CI are the following:
1. Update the submodule `ivoatex`:
    ```bash
    cd ivoatex/
    git pull
    cd ..
    git add ivoatex/
    git commit -m "Update ivoatex"
    ```
2. Run `update-ci`
    ```bash
    make update-ci
    ```
3. Commit the updated CI
    ```bash
    git add .github/workflows/build.yml .github/workflows/preview.yml
    git commit -m "Update CI for build and PDF preview"
    ```
4. Push all these modifications
    ```bash
    git push
    ```
5. [Optional] On the Releases page of your GitHub repositories, manually remove all the Draft (but not the Pre-Release otherwise you will loose your PDF preview) releases named `Auto PDF Preview` (they are the unfortunate result of an issue with the former CI workflow). Thanks to the updated CI, there should be only one `Auto PDF Preview` Pre-Release (and no more Draft with the same name) from now on.

-----

I also tried to optimize both workflows by caching the installation of LaTeX packages, in order to avoid this long step every time a CI runs. Because the installation of these packages requires configuration of some files, I failed to perform this optimization. Another solution would be to start these workflows with a custom image already containing all needed LaTeX packages. This may be done later in another PullRequest.