### PR TITLE
Fix installation of dependencies

### DIFF
--- a/github_workflow_build.yml.template
+++ b/github_workflow_build.yml.template
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install texlive-latex-base texlive-latex-recommended \
-                         texlive-latex-extra texlive-fonts-recommended
+                         texlive-latex-extra texlive-fonts-recommended \
                          pdftk xsltproc latexmk cm-super
 
     - name: Build the document

--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -31,7 +31,7 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt install texlive-latex-base texlive-latex-recommended \
-                         texlive-latex-extra texlive-fonts-recommended
+                         texlive-latex-extra texlive-fonts-recommended \
                          pdftk xsltproc latexmk cm-super
 
     - name: Build the document


### PR DESCRIPTION
A missing `\` skipped the installation of pdftk, xsltproc, latexmk and cm-super.
This commit should fix this problem.

_Problem mentioned in https://github.com/ivoa-std/DALI/pull/45 and in #140_