### PR TITLE
Fix `doc_name` in `update-ci` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,14 +296,14 @@ $(GITHUB_WORKFLOWS):
 	@mkdir -p $@
 
 $(GITHUB_BUILD): $(GITHUB_WORKFLOWS) $(GITHUB_BUILD_TEMPLATE)
-	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_BUILD_TEMPLATE) > $@
+	@sed "s!^\(\s*doc_name\s*:\)!\1 $(DOCNAME)!g" $(GITHUB_BUILD_TEMPLATE) > $@
 	@git add "$@"
 	@echo "* GitHub Workflow Build (to check compilation of the IVOA document)\
 	         \n  in PullRequest configured:\n                 $@"
 	@echo '  => Run "git commit && git push" to enable this Build workflow.'
 
 $(GITHUB_PREVIEW): $(GITHUB_WORKFLOWS) $(GITHUB_PREVIEW_TEMPLATE)
-	@sed "s!^\(\s*doc_name:\)!\1 $(DOCNAME)!g" $(GITHUB_PREVIEW_TEMPLATE) > $@
+	@sed "s!^\(\s*doc_name\s*:\)!\1 $(DOCNAME)!g" $(GITHUB_PREVIEW_TEMPLATE) > $@
 	@git add "$@"
 	@echo "* GitHub Workflow for PDF preview at pushed commit configured:\
 	         \n                 $@\n\


### PR DESCRIPTION
This aims to fix the substitution of the property `doc_name` in the build and preview GitHub workflows.

See issue raised in https://github.com/ivoa-std/DALI/pull/45