### PR TITLE
check git is available in gitmeta.tex target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ untag:
 .FORCE:
 
 gitmeta.tex: .FORCE
+	@git log --oneline -0  # check git is present
 	@/bin/echo -n '\vcsrevision{' > $@
 	@/bin/echo -n "$(shell git log -1 --date=short --pretty=%h 2> /dev/null)" >> $@
 	@if [ ! -z "$(shell git status --porcelain -uno 2> /dev/null)" ]; then /bin/echo -n -dirty >> $@; fi


### PR DESCRIPTION
Add a line checking that the git command is present, i.e. the make will fail if it's not.  Prevents silent production of an uninformative gitmeta.tex file in absence of git.

Absence of git may seem like an unlikely eventuality for an ivoatex build, but it has happened when building documents from docker.