### PR TITLE
On make tag, only push the newly-made tag now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ update:
 
 tag:
 	git tag $(versionedName)
-	git push origin --tags $(versionedName)
+	git push origin $(versionedName)
 
 untag:
 	git tag -d $(versionedName)


### PR DESCRIPTION
This is because the preview workflow sets and moves a tag auto-pdf-preview that will keep conflicting when people have longer-lived checkouts.