### PR TITLE
git existence check no longer opens a pager.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ untag:
 .FORCE:
 
 gitmeta.tex: .FORCE
-	@git log --oneline -0  # check git is present
+	@git -P log --oneline -0  # check git is present
 	@/bin/echo -n '\vcsrevision{' > $@
 	@/bin/echo -n "$(shell git log -1 --date=short --pretty=%h 2> /dev/null)" >> $@
 	@if [ ! -z "$(shell git status --porcelain -uno 2> /dev/null)" ]; then /bin/echo -n -dirty >> $@; fi


### PR DESCRIPTION
When making gitmeta.tex, we now test for git by running a short log. At least sometimes, this want to enter a pager, which is unwelcome when running make.  The extra -P switch prevents that.