### PR TITLE
Adding a vocterm macro

### DIFF
--- a/ivoa.cls
+++ b/ivoa.cls
@@ -18,6 +18,8 @@
 
 \definecolor{ivoacolor}{rgb}{0.0,0.318,0.612}
 \definecolor{linkcolor}{rgb}{0.318,0,0.318}
+\definecolor{termcolor}{rgb}{0.6,0.1,0.1}
+
 
 \RequirePackage[colorlinks,
 	linkcolor=linkcolor,
@@ -360,6 +362,15 @@
   \catcode`\.=\active\let.=\bre@kabledot
   \catcode`\;=\active\let;=\bre@kablesemicolon}
 \gdef\@nducd{\endgroup}
+\endgroup
+\def\vocterm{\startvocterm\realvocterm}
+\def\realvocterm#1{\emph{\color{termcolor}#1}\endvocterm}
+\begingroup
+\gdef\breakablecolon{:\hskip0pt}
+\catcode`\:=\active
+\gdef\startvocterm{\begingroup
+  \catcode`\:=\active\let:=\breakablecolon}
+\gdef\endvocterm{\endgroup}
 \endgroup
 
 \newcommand{\sptablerule}{\noalign{\vspace{2pt}}\hline\noalign{\vspace{2pt}}}

--- a/tthdefs.tex
+++ b/tthdefs.tex
@@ -9,6 +9,8 @@
 
 
 \definecolor{ivoacolor}{rgb}{0.0,0.318,0.612}
+\definecolor{termcolor}{rgb}{0.6,0.1,0.1}
+
 
 %%%%%%%%%%%%%%%%%%% ivoatex features
 
@@ -111,6 +113,7 @@
 \newcommand{\specialterm}[2]{\begin{html}<span class="#1">\end{html}#2\begin{html}</span>\end{html}}
 \newcommand{\xmlel}[1]{\specialterm{xmlel}{#1}}
 \newcommand{\vorent}[1]{\specialterm{vorent}{#1}}
+\newcommand{\vocterm}[1]{\emph{\color{termcolor}#1}}
 \newcommand{\ucd}[1]{{\sl #1}}
 
 %don't do table rules, these come in through CSS


### PR DESCRIPTION
We now have enough documents wanting to mark up terms from vocabularies that ivoatex should have that feature (lifted from VocInVO2).

This PR adds it.  It is a bit more complicated than ordinary semantic markup because we want to enable hyphenation when terms are used with prefixes, as is usual with non-IVOA vocabularies ("foaf:person").  I think the savings in typographic hassle are worth the extra TeX code.