### PR TITLE
add some RFCs to ivoabib.bib

### DIFF
--- a/ivoabib.bib
+++ b/ivoabib.bib
@@ -842,3 +842,65 @@ archivePrefix = {ascl},
        Url = {https://ivoa.net/documents/Notes/IVOATexDoc/},
        Year = {2022}
 }
+
+@Misc{std:RFC2965,
+  author =       {Lou Montulli and David M. Kristol},
+  title =        {{HTTP State Management Mechanism}},
+  howpublished = {RFC 2965},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc2965.html},
+  month =        oct,
+  year =         2000
+}
+
+@Misc{std:RFC6265,
+  author =       {Adam Barth},
+  title =        {{HTTP State Management Mechanism}},
+  howpublished = {RFC 6265},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc6265.html},
+  month =        apr,
+  year =         2011
+}
+
+@Misc{std:RFC6750,
+  author =       {Michael B. Jones and Dick Hardt},
+  title =        {{The OAuth 2.0 Authorization Framework: Bearer Token Usage}},
+  howpublished = {RFC 6750},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc6750.html},
+  month =        oct,
+  year =         2012
+}
+
+@Misc{std:RFC7616,
+  author =       {Rifaat Shekh-Yusef and David Ahrens and Sophie Bremer},
+  title =        {{HTTP Digest Access Authentication}},
+  howpublished = {RFC 7616},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc7616.html},
+  month =        sep,
+  year =         2015
+}
+
+@Misc{std:RFC7617,
+  author =       {J. Reschke},
+  title =        {The 'Basic' HTTP Authentication Scheme},
+  howpublished = {RFC 7617},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc7617.html},
+  month =        sep,
+  year =         2015
+}
+
+@Misc{std:RFC9110,
+  author =       {Roy T. Fielding and Mark Nottingham and Julian Reschke},
+  title =        {{HTTP Semantics}},
+  howpublished = {RFC 9110},
+  organization = {{IETF}},
+  url =          {https://www.ietf.org/rfc/rfc9110.html},
+  month =        jun,
+  year =         2022
+}
+
+


### PR DESCRIPTION
Mostly related to HTTP authentication.
Unlike the existing RFCs in there, I've set the URLs to the .html rather than the .txt version of the content.