### PR TITLE
add apt update to preview action template

### DIFF
--- a/github_workflow_preview.yml.template
+++ b/github_workflow_preview.yml.template
@@ -30,6 +30,7 @@ jobs:
 
     - name: Setup dependencies
       run: |
+        sudo apt update
         sudo apt install texlive-latex-base texlive-latex-recommended \
                          texlive-latex-extra texlive-fonts-recommended \
                          librsvg2-bin latexmk \


### PR DESCRIPTION
I don't have a deep understanding of the CI here, but making a change equivalent to this fixed a preview build failure for AuthVO, so I guess the same edit should be in place in the upstream template.