### PR TITLE
Fix to make tth compile work for gcc 15.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ CSS_HREF = https://www.ivoa.net/misc/ivoa_doc.css
 TTH = ivoatex/tth_C/tth
 ARCHIVE_FILES = $(DOCNAME).tex $(DOCNAME).pdf $(DOCNAME).html $(FIGURES)
 PYTHON?=python3
+CC?=gcc
+CFLAGS?="-std=gnu17"
 
 #  Requirements:
 #     XSLT processor
@@ -234,7 +236,7 @@ upload: package
 #  TtH source seems to be highly portable, so compilation should be easy
 #  as long as you have a C compiler.
 $(TTH): ivoatex/tth_C/tth.c
-	$(CC) -o $(TTH) ivoatex/tth_C/tth.c
+	$(CC) $(CFLAGS) -o $(TTH) ivoatex/tth_C/tth.c
 
 ############# architecture diagram stuff (to be executed in this directory)
 


### PR DESCRIPTION
GCC 15 interprets the external and static declarations that tth has as prototypes and then fails compilation without forcing it back to gnu17. It would of course be preferable to fix the tth source; Ian is disinclined to do so.  Perhaps we'll need to fork it one day.

For now, I'm going for the forcing.  This is a bit unfortunate in that we are now chained to gcc unless people define CC and CFLAGS themselves.  I forsee trouble on OSX...

This is an attempt to fix #165.