### PR TITLE
Fixing previous URL calculation for notes.

### DIFF
--- a/newrelease.py
+++ b/newrelease.py
@@ -34,7 +34,10 @@ def add_previous_version(spec):
     to docname.tex.
     """
     docname = spec["Docname"]
-    cur_document_url = spec["BaseURL"]+"/"+spec["Docdatecode"]
+    if spec["Doctype"]=="NOTE":
+        cur_document_url = spec["BaseURL"]+"/"
+    else:
+        cur_document_url = spec["BaseURL"]+"/"+spec["Docdatecode"]
 
     if os.environ.get("IVOATEX_HUSH")!="shsh":
         print("I am opening a web browser that should show the last\n"


### PR DESCRIPTION
In the current docrepo, Notes don't have date tags.  This PR reflects this in newrelease.py's previous URL calculation.  Of course, this whole thing doesn't make much sense now because the previous document URL will be the same as the current one.  But this needs to be fixed in the doc repo.  For now, I think we need to reflect actual practices.  Hm.