### PR TITLE
Use committer date not author date for \vcsdate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ gitmeta.tex: .FORCE
 	@/bin/echo -n "$(shell git log -1 --date=short --pretty=%h 2> /dev/null)" >> $@
 	@if [ ! -z "$(shell git status --porcelain -uno 2> /dev/null)" ]; then /bin/echo -n -dirty >> $@; fi
 	@/bin/echo } >> $@
-	@/bin/echo '\vcsdate{' $(shell git log -1 --date=short --pretty=%ai 2> /dev/null) '}' >>$@
+	@/bin/echo '\vcsdate{' $(shell git log -1 --date=short --pretty=%ci 2> /dev/null) '}' >>$@
 
 
 ivoatexmeta.tex: Makefile


### PR DESCRIPTION
I think the committer date makes more sense here, since it's going to be more recent.  In the case that there is commit reordering, the author date may be some time before the effective application of the change, so this will result in a more up-to-date view of when the most recent changes to the source happened.